### PR TITLE
chore(pass-webauthn): update tests to use latest version of pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,15 +39,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -445,9 +445,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -618,9 +618,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.21"
+version = "1.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
+checksum = "32db95edf998450acc7881c932f94cd9b05c87b4b2599e8bab064753da4acfd1"
 dependencies = [
  "shlex",
 ]
@@ -708,7 +708,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "fc-pallet-pass"
 version = "1.0.0"
-source = "git+https://github.com/virto-network/frame-contrib#8824865a3d2f10620e5e037ed95e11fefba142b8"
+source = "git+https://github.com/virto-network/frame-contrib?branch=fix%2Fprevent-reusing-attestations-assertions#33ed36071a2e57657c62e333eca45fccb63db576"
 dependencies = [
  "fc-traits-authn",
  "frame-benchmarking",
@@ -1157,7 +1157,7 @@ dependencies = [
 [[package]]
 name = "fc-traits-authn"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/frame-contrib#8824865a3d2f10620e5e037ed95e11fefba142b8"
+source = "git+https://github.com/virto-network/frame-contrib?branch=fix%2Fprevent-reusing-attestations-assertions#33ed36071a2e57657c62e333eca45fccb63db576"
 dependencies = [
  "fc-traits-authn-proc",
  "frame-support",
@@ -1169,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "fc-traits-authn-proc"
 version = "0.1.0"
-source = "git+https://github.com/virto-network/frame-contrib#8824865a3d2f10620e5e037ed95e11fefba142b8"
+source = "git+https://github.com/virto-network/frame-contrib?branch=fix%2Fprevent-reusing-attestations-assertions#33ed36071a2e57657c62e333eca45fccb63db576"
 dependencies = [
  "proc-macro-crate",
  "quote",
@@ -1257,7 +1257,7 @@ dependencies = [
 [[package]]
 name = "form_urlencoded"
 version = "1.2.1"
-source = "git+https://github.com/servo/rust-url#7cff87405a73259c9fcf3211a47992402b23c22c"
+source = "git+https://github.com/servo/rust-url#68f151c01682d620605b749b61684084150a6c41"
 dependencies = [
  "percent-encoding 2.3.1 (git+https://github.com/servo/rust-url)",
 ]
@@ -1600,8 +1600,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1770,21 +1782,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1794,30 +1807,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1825,65 +1818,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -1900,7 +1880,7 @@ dependencies = [
 [[package]]
 name = "idna"
 version = "1.0.3"
-source = "git+https://github.com/servo/rust-url#7cff87405a73259c9fcf3211a47992402b23c22c"
+source = "git+https://github.com/servo/rust-url#68f151c01682d620605b749b61684084150a6c41"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -1909,9 +1889,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2133,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -2212,9 +2192,9 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -2607,7 +2587,7 @@ dependencies = [
  "ciborium",
  "coset",
  "data-encoding",
- "getrandom",
+ "getrandom 0.2.16",
  "hmac 0.12.1",
  "indexmap",
  "p256",
@@ -2665,7 +2645,7 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 [[package]]
 name = "percent-encoding"
 version = "2.3.1"
-source = "git+https://github.com/servo/rust-url#7cff87405a73259c9fcf3211a47992402b23c22c"
+source = "git+https://github.com/servo/rust-url#68f151c01682d620605b749b61684084150a6c41"
 
 [[package]]
 name = "pin-project-lite"
@@ -2763,6 +2743,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2774,7 +2763,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -2909,6 +2898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,7 +2936,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2952,9 +2947,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -4157,9 +4152,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4404,18 +4399,12 @@ dependencies = [
 [[package]]
 name = "url"
 version = "2.5.4"
-source = "git+https://github.com/servo/rust-url#7cff87405a73259c9fcf3211a47992402b23c22c"
+source = "git+https://github.com/servo/rust-url#68f151c01682d620605b749b61684084150a6c41"
 dependencies = [
  "form_urlencoded 1.2.1 (git+https://github.com/servo/rust-url)",
  "idna 1.0.3 (git+https://github.com/servo/rust-url)",
  "percent-encoding 2.3.1 (git+https://github.com/servo/rust-url)",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -4530,6 +4519,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -4764,24 +4762,27 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.0",
+]
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wyz"
@@ -4794,9 +4795,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4806,9 +4807,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4818,31 +4819,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -4898,10 +4879,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4910,9 +4902,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,8 @@ pallet-balances = { version = "41.1.0", default-features = false }
 pallet-scheduler = { version = "41.0.0", default-features = false }
 
 # FRAME Contrib
-traits-authn = { git = "https://github.com/virto-network/frame-contrib", package = "fc-traits-authn", default-features = false }
-pallet-pass = { git = "https://github.com/virto-network/frame-contrib", package = "fc-pallet-pass", default-features = false }
+traits-authn = { git = "https://github.com/virto-network/frame-contrib", branch = "fix/prevent-reusing-attestations-assertions", package = "fc-traits-authn", default-features = false }
+pallet-pass = { git = "https://github.com/virto-network/frame-contrib", branch = "fix/prevent-reusing-attestations-assertions", package = "fc-pallet-pass", default-features = false }
 
 # Local Crates
 verifier = { path = "verifier", default-features = false }

--- a/pass-webauthn/src/tests.rs
+++ b/pass-webauthn/src/tests.rs
@@ -6,7 +6,7 @@ use frame::{
     testing_prelude::*,
     traits::{ConstU32, EqualPrivilegeOnly},
 };
-use traits_authn::{util::AuthorityFromPalletId, Challenger, HashedUserId};
+use traits_authn::{util::AuthorityFromPalletId, Challenger, ExtrinsicContext, HashedUserId};
 
 use crate::Authenticator;
 
@@ -83,53 +83,73 @@ pub struct BlockChallenger;
 impl Challenger for BlockChallenger {
     type Context = BlockNumberFor<Test>;
 
-    fn generate(ctx: &Self::Context) -> traits_authn::Challenge {
-        <Test as frame_system::Config>::Hashing::hash(&ctx.to_le_bytes()).0
+    fn generate(ctx: &Self::Context, xtc: &impl ExtrinsicContext) -> traits_authn::Challenge {
+        <Test as frame_system::Config>::Hashing::hash(&((ctx, xtc.as_ref()).encode())).0
+    }
+}
+
+pub struct SumAddressGenerator;
+impl AddressGenerator<Test, ()> for SumAddressGenerator {
+    fn generate_address(id: HashedUserId) -> AccountId {
+        id.iter()
+            .map(|b| *b as u64)
+            .reduce(Saturating::saturating_add)
+            .unwrap()
     }
 }
 
 impl pallet_pass::Config for Test {
     type RuntimeEvent = RuntimeEvent;
-    type RuntimeCall = RuntimeCall;
-    type Currency = Balances;
-    type WeightInfo = ();
-    type Authenticator = Authenticator<BlockChallenger, AuthorityId>;
     type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type WeightInfo = ();
+    type RegisterOrigin = EnsureRootWithSuccess<Self::AccountId, ConstU64<0>>;
+    type AddressGenerator = SumAddressGenerator;
+    type Balances = Balances;
+    type Authenticator = Authenticator<BlockChallenger, AuthorityId>;
+    type Scheduler = Scheduler;
+    type RegistrarConsideration = ();
+    type DeviceConsideration = ();
+    type SessionKeyConsideration = ();
     type PalletId = PassPalletId;
     type MaxSessionDuration = ConstU64<10>;
-    type RegisterOrigin = EnsureRootWithSuccess<Self::AccountId, NeverPays>;
-    type Scheduler = Scheduler;
     #[cfg(feature = "runtime-benchmarks")]
     type BenchmarkHelper = Helper;
 }
 
 #[cfg(feature = "runtime-benchmarks")]
 use hashing::blake2_256;
+use pallet_pass::AddressGenerator;
+
 #[cfg(feature = "runtime-benchmarks")]
 pub struct Helper;
 #[cfg(feature = "runtime-benchmarks")]
 impl pallet_pass::BenchmarkHelper<Test> for Helper {
-    fn register_origin() -> frame_system::pallet_prelude::OriginFor<Test> {
-        RuntimeOrigin::root()
-    }
-
-    fn device_attestation(_: traits_authn::DeviceId) -> pallet_pass::DeviceAttestationOf<Test, ()> {
+    fn device_attestation(
+        _: traits_authn::DeviceId,
+        xtc: &impl ExtrinsicContext,
+    ) -> pallet_pass::DeviceAttestationOf<Test, ()> {
         WebAuthnClient::new("https://pass_web.pass.int", 1)
             .attestation(
                 blake2_256(b"USER_ID"),
                 System::block_number(),
+                xtc,
                 AuthorityId::get(),
             )
             .1
     }
 
-    fn credential(user_id: HashedUserId) -> pallet_pass::CredentialOf<Test, ()> {
+    fn credential(
+        user_id: HashedUserId,
+        xtc: &impl ExtrinsicContext,
+    ) -> pallet_pass::CredentialOf<Test, ()> {
         let mut client = WebAuthnClient::new("https://helper.pass.int", 2);
         let (credential_id, _) =
-            client.attestation(user_id, System::block_number(), AuthorityId::get());
+            client.attestation(user_id, System::block_number(), xtc, AuthorityId::get());
         client.assertion(
             credential_id.as_slice(),
             System::block_number(),
+            xtc,
             AuthorityId::get(),
         )
     }
@@ -161,7 +181,7 @@ mod attestation {
     fn registration_fails_if_attestation_is_invalid() {
         new_test_ext(1).execute_with(|client| {
             let (_, mut attestation) =
-                client.attestation(USER, System::block_number(), AuthorityId::get());
+                client.attestation(USER, System::block_number(), &[], AuthorityId::get());
 
             // Alters "challenge", so this will fail
             attestation.client_data = String::from_utf8(attestation.client_data)
@@ -187,7 +207,7 @@ mod attestation {
                 RuntimeOrigin::root(),
                 USER,
                 client
-                    .attestation(USER, System::block_number(), AuthorityId::get())
+                    .attestation(USER, System::block_number(), &[], AuthorityId::get())
                     .1
             ));
         })
@@ -196,14 +216,14 @@ mod attestation {
 
 mod assertion {
     use traits_authn::DeviceChallengeResponse;
-
+    use crate::tests::sp_api_hidden_includes_construct_runtime::hidden_include::sp_runtime::traits::TxBaseImplication;
     use super::*;
 
     #[test]
     fn authentication_fails_if_credentials_are_invalid() {
         new_test_ext(2).execute_with(|client| {
             let (credential_id, attestation) =
-                client.attestation(USER, System::block_number(), AuthorityId::get());
+                client.attestation(USER, System::block_number(), &[], AuthorityId::get());
 
             assert_ok!(Pass::register(
                 RuntimeOrigin::root(),
@@ -211,18 +231,29 @@ mod assertion {
                 attestation.clone()
             ));
 
-            let mut assertion =
-                client.assertion(credential_id, System::block_number(), AuthorityId::get());
-            assertion.signature = [assertion.signature, b"Whoops".to_vec()].concat();
+            let assertion = client.assertion(
+                credential_id,
+                System::block_number(),
+                &[],
+                AuthorityId::get(),
+            );
+
+            let ext =
+                pallet_pass::PassAuthenticate::<Test>::from(*attestation.device_id(), assertion);
+
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
 
             assert_noop!(
-                Pass::authenticate(
-                    RuntimeOrigin::signed(1),
-                    *(attestation.device_id()),
-                    assertion,
-                    None
-                ),
-                pallet_pass::Error::<Test>::CredentialInvalid
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
             );
         })
     }
@@ -231,7 +262,7 @@ mod assertion {
     fn authentication_works_if_credentials_are_valid() {
         new_test_ext(2).execute_with(|client| {
             let (credential_id, attestation) =
-                client.attestation(USER, System::block_number(), AuthorityId::get());
+                client.attestation(USER, System::block_number(), &[], AuthorityId::get());
 
             assert_ok!(Pass::register(
                 RuntimeOrigin::root(),
@@ -239,12 +270,29 @@ mod assertion {
                 attestation.clone()
             ));
 
-            assert_ok!(Pass::authenticate(
-                RuntimeOrigin::signed(1),
-                *(attestation.device_id()),
-                client.assertion(credential_id, System::block_number(), AuthorityId::get()),
-                None
-            ));
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            let assertion = client.assertion(
+                credential_id,
+                System::block_number(),
+                &TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256),
+                AuthorityId::get(),
+            );
+
+            let ext =
+                pallet_pass::PassAuthenticate::<Test>::from(*attestation.device_id(), assertion);
+
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    extrinsic_version,
+                )
+                .map(|_| ()));
         })
     }
 }

--- a/pass-webauthn/src/tests/authenticator_client.rs
+++ b/pass-webauthn/src/tests/authenticator_client.rs
@@ -140,9 +140,10 @@ impl WebAuthnClient {
         &mut self,
         user_id: HashedUserId,
         context: BlockNumberFor<Test>,
+        xtc: &impl ExtrinsicContext,
         authority_id: AuthorityId,
     ) -> (Vec<u8>, crate::Attestation<BlockNumberFor<Test>>) {
-        let challenge = BlockChallenger::generate(&context);
+        let challenge = BlockChallenger::generate(&context, xtc);
 
         let (credential_id, authenticator_data, client_data, public_key) = self
             .create_credential_sync(user_id, challenge.as_slice())
@@ -167,9 +168,10 @@ impl WebAuthnClient {
         &mut self,
         credential_id: impl Into<Bytes>,
         context: BlockNumberFor<Test>,
+        xtc: &impl ExtrinsicContext,
         authority_id: AuthorityId,
     ) -> crate::Assertion<BlockNumberFor<Test>> {
-        let challenge = BlockChallenger::generate(&context);
+        let challenge = BlockChallenger::generate(&context, xtc);
 
         let (user_handle, authenticator_data, client_data, signature) = self
             .authenticate_credential_sync(credential_id, challenge.as_slice())


### PR DESCRIPTION
 that includes `ExtrinsicContext`