### PR TITLE
feat: add Ethereum, Bitcoin, Solana, Nostr, and SSH authenticators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,6 +2730,7 @@ dependencies = [
  "pallet-scheduler",
  "parity-scale-codec",
  "polkadot-sdk-frame",
+ "ripemd",
  "scale-info",
  "sp-core",
  "sp-io",
@@ -3347,6 +3348,15 @@ checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
  "hmac",
  "subtle",
+]
+
+[[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,6 +2234,7 @@ dependencies = [
  "once_cell",
  "serdect",
  "sha2 0.10.9",
+ "signature",
 ]
 
 [[package]]
@@ -2716,6 +2717,92 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pass-authenticators-bitcoin"
+version = "0.1.0"
+dependencies = [
+ "fc-pallet-pass",
+ "fc-traits-authn",
+ "log",
+ "pallet-balances",
+ "pallet-scheduler",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pass-authenticators-ethereum"
+version = "0.1.0"
+dependencies = [
+ "fc-pallet-pass",
+ "fc-traits-authn",
+ "log",
+ "pallet-balances",
+ "pallet-scheduler",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pass-authenticators-nostr"
+version = "0.1.0"
+dependencies = [
+ "fc-pallet-pass",
+ "fc-traits-authn",
+ "k256",
+ "log",
+ "pallet-balances",
+ "pallet-scheduler",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pass-authenticators-solana"
+version = "0.1.0"
+dependencies = [
+ "fc-pallet-pass",
+ "fc-traits-authn",
+ "log",
+ "pallet-balances",
+ "pallet-scheduler",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pass-authenticators-ssh"
+version = "0.1.0"
+dependencies = [
+ "fc-pallet-pass",
+ "fc-traits-authn",
+ "log",
+ "pallet-balances",
+ "pallet-scheduler",
+ "parity-scale-codec",
+ "polkadot-sdk-frame",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2755,6 +2755,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pass-authenticators-integration-tests"
+version = "0.1.0"
+dependencies = [
+ "fc-pallet-pass",
+ "fc-traits-authn",
+ "k256",
+ "log",
+ "pallet-balances",
+ "pallet-scheduler",
+ "parity-scale-codec",
+ "pass-authenticators-bitcoin",
+ "pass-authenticators-ethereum",
+ "pass-authenticators-nostr",
+ "pass-authenticators-solana",
+ "pass-authenticators-ssh",
+ "polkadot-sdk-frame",
+ "ripemd",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+]
+
+[[package]]
 name = "pass-authenticators-nostr"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,5 +61,5 @@ traits-authn = { git = "https://github.com/virto-network/frame-contrib", package
 pallet-pass = { git = "https://github.com/virto-network/frame-contrib", package = "fc-pallet-pass", default-features = false }
 
 [workspace]
-members = ["authenticators/*"]
+members = ["authenticators/*", "integration-tests"]
 resolver = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,8 +42,12 @@ scale-info = { version = "2.11.6", default-features = false, features = [
 serde = { version = "1.0.219", default-features = false }
 serde_json = { version = "1.0.141", default-features = false }
 
+# Crypto
+k256 = { version = "0.13.4", default-features = false, features = ["schnorr", "alloc", "pkcs8"] }
+
 # Substrate
 sp-core = { version = "39.0.0", default-features = false }
+sp-io = { version = "44.0.0", default-features = false }
 sp-runtime = { version = "45.0.0", default-features = false }
 
 # FRAME

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde_json = { version = "1.0.141", default-features = false }
 
 # Crypto
 k256 = { version = "0.13.4", default-features = false, features = ["schnorr", "alloc", "pkcs8"] }
+ripemd = { version = "0.1.3", default-features = false }
 
 # Substrate
 sp-core = { version = "39.0.0", default-features = false }

--- a/authenticators/bitcoin/Cargo.toml
+++ b/authenticators/bitcoin/Cargo.toml
@@ -9,6 +9,7 @@ version = "0.1.0"
 [dependencies]
 codec.workspace = true
 log.workspace = true
+ripemd.workspace = true
 scale-info.workspace = true
 sp-core.workspace = true
 sp-io.workspace = true
@@ -32,6 +33,7 @@ std = [
   "pallet-balances/std",
   "pallet-pass/std",
   "pallet-scheduler/std",
+  "ripemd/std",
   "scale-info/std",
   "sp-core/std",
   "sp-io/std",

--- a/authenticators/bitcoin/Cargo.toml
+++ b/authenticators/bitcoin/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+name = "pass-authenticators-bitcoin"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+codec.workspace = true
+log.workspace = true
+scale-info.workspace = true
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+traits-authn.workspace = true
+
+[dev-dependencies]
+frame.workspace = true
+pallet-balances.workspace = true
+pallet-pass.workspace = true
+pallet-scheduler.workspace = true
+
+[features]
+default = ["std", "runtime", "full-crypto"]
+runtime = []
+full-crypto = ["sp-core/full_crypto"]
+std = [
+  "codec/std",
+  "frame/std",
+  "log/std",
+  "pallet-balances/std",
+  "pallet-pass/std",
+  "pallet-scheduler/std",
+  "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "traits-authn/std",
+]
+try-runtime = [
+  "pallet-pass/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-scheduler/try-runtime",
+  "frame/try-runtime",
+  "sp-runtime/try-runtime",
+]

--- a/authenticators/bitcoin/src/btc.rs
+++ b/authenticators/bitcoin/src/btc.rs
@@ -75,20 +75,13 @@ pub fn recover_btc_pubkey_hash(
 
     if compressed {
         let pubkey = sp_io::crypto::secp256k1_ecdsa_recover_compressed(&sig, message_hash).ok()?;
-        // HASH160 = RIPEMD160(SHA256(compressed_pubkey))
-        // Since we don't have RIPEMD160 in sp_io, we approximate with
-        // SHA256 and take 20 bytes. For production, add a RIPEMD160 crate.
-        // Actually, let's use the full 33-byte compressed pubkey hash.
-        let hash = hash160(&pubkey);
-        Some(BtcPubkeyHash::from_hash160(hash))
+        Some(BtcPubkeyHash::from_hash160(hash160(&pubkey)))
     } else {
         let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(&sig, message_hash).ok()?;
-        // Uncompressed: 0x04 || x[32] || y[32]
         let mut uncompressed = [0u8; 65];
         uncompressed[0] = 0x04;
         uncompressed[1..].copy_from_slice(&pubkey);
-        let hash = hash160(&uncompressed);
-        Some(BtcPubkeyHash::from_hash160(hash))
+        Some(BtcPubkeyHash::from_hash160(hash160(&uncompressed)))
     }
 }
 

--- a/authenticators/bitcoin/src/btc.rs
+++ b/authenticators/bitcoin/src/btc.rs
@@ -5,9 +5,11 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 impl<Cx: Encode> SignedMessage<Cx> {
-    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    /// The domain-separated payload bytes.
+    /// Prefixed with `b"BTC"` to prevent cross-authenticator signature replay.
     pub fn payload(&self) -> Vec<u8> {
         [
+            b"BTC".as_slice(),
             self.context.encode().as_ref(),
             &self.challenge[..],
             &self.authority_id[..],
@@ -58,13 +60,11 @@ pub fn recover_btc_pubkey_hash(
     signature: &[u8; 65],
 ) -> Option<BtcPubkeyHash> {
     // BIP-137: first byte is recovery flag
-    // 27-30: uncompressed, 31-34: compressed
+    // 27-30: uncompressed key, 31-34: compressed key
     let flag = signature[0];
     let (recovery_id, compressed) = match flag {
         27..=30 => (flag - 27, false),
         31..=34 => (flag - 31, true),
-        // Also accept raw recovery id (0-3) for compatibility
-        0..=3 => (flag, true),
         _ => return None,
     };
 
@@ -93,16 +93,12 @@ pub fn recover_btc_pubkey_hash(
 }
 
 /// Bitcoin HASH160: RIPEMD160(SHA256(data)).
-/// Since `sp_io` doesn't provide RIPEMD160, we use a simplified approach:
-/// take the first 20 bytes of SHA256(SHA256(data)).
-/// NOTE: For full Bitcoin compatibility, a proper RIPEMD160 implementation
-/// should be used. This works for our authentication purposes since both
-/// sides (registration and verification) use the same derivation.
 fn hash160(data: &[u8]) -> [u8; 20] {
-    let hash = sha2_256(&sha2_256(data));
-    let mut result = [0u8; 20];
-    result.copy_from_slice(&hash[..20]);
-    result
+    use ripemd::{Digest, Ripemd160};
+    let sha = sha2_256(data);
+    let mut hasher = Ripemd160::new();
+    hasher.update(sha);
+    hasher.finalize().into()
 }
 
 #[cfg(feature = "full-crypto")]

--- a/authenticators/bitcoin/src/btc.rs
+++ b/authenticators/bitcoin/src/btc.rs
@@ -95,20 +95,13 @@ fn hash160(data: &[u8]) -> [u8; 20] {
 }
 
 #[cfg(feature = "full-crypto")]
-pub trait Sign<Cx> {
+impl<Cx: Encode> SignedMessage<Cx> {
     /// Sign the message with a secp256k1 key, producing a 65-byte BIP-137 signature.
-    fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65];
-}
-
-#[cfg(feature = "full-crypto")]
-impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
-    fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65] {
+    pub fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65] {
         let hash = self.btc_message_hash();
         let raw_sig = pair.sign_prehashed(&hash);
-        // Convert to BIP-137 format: flag[1] || r[32] || s[32]
-        // Use compressed key flag (31 + recovery_id)
         let mut btc_sig = [0u8; 65];
-        btc_sig[0] = 31 + raw_sig.0[64]; // compressed flag + recovery_id
+        btc_sig[0] = 31 + raw_sig.0[64];
         btc_sig[1..].copy_from_slice(&raw_sig.0[..64]);
         btc_sig
     }

--- a/authenticators/bitcoin/src/btc.rs
+++ b/authenticators/bitcoin/src/btc.rs
@@ -1,0 +1,126 @@
+use super::*;
+use sp_io::hashing::sha2_256;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+impl<Cx: Encode> SignedMessage<Cx> {
+    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    pub fn payload(&self) -> Vec<u8> {
+        [
+            self.context.encode().as_ref(),
+            &self.challenge[..],
+            &self.authority_id[..],
+        ]
+        .concat()
+    }
+
+    /// Compute the Bitcoin message hash (double SHA256).
+    /// Format: SHA256(SHA256("\x18Bitcoin Signed Message:\n" || varint(len) || payload))
+    pub fn btc_message_hash(&self) -> [u8; 32] {
+        let payload = self.payload();
+        bitcoin_message_hash(&payload)
+    }
+}
+
+/// Encode a length as a Bitcoin-style varint.
+fn varint(len: usize) -> Vec<u8> {
+    if len < 0xFD {
+        alloc::vec![len as u8]
+    } else if len <= 0xFFFF {
+        let mut v = alloc::vec![0xFD];
+        v.extend_from_slice(&(len as u16).to_le_bytes());
+        v
+    } else {
+        let mut v = alloc::vec![0xFE];
+        v.extend_from_slice(&(len as u32).to_le_bytes());
+        v
+    }
+}
+
+/// Hash using Bitcoin Signed Message format (double SHA256).
+/// `SHA256(SHA256("\x18Bitcoin Signed Message:\n" || varint(len) || message))`
+pub fn bitcoin_message_hash(message: &[u8]) -> [u8; 32] {
+    let prefix = b"\x18Bitcoin Signed Message:\n";
+    let mut data = Vec::with_capacity(prefix.len() + 5 + message.len());
+    data.extend_from_slice(prefix);
+    data.extend_from_slice(&varint(message.len()));
+    data.extend_from_slice(message);
+    sha2_256(&sha2_256(&data))
+}
+
+/// Recover a Bitcoin public key hash (HASH160) from a signed message.
+///
+/// The signature format follows BIP-137: recovery_flag[1] || r[32] || s[32]
+/// where recovery_flag encodes the recovery id and key compression.
+pub fn recover_btc_pubkey_hash(
+    message_hash: &[u8; 32],
+    signature: &[u8; 65],
+) -> Option<BtcPubkeyHash> {
+    // BIP-137: first byte is recovery flag
+    // 27-30: uncompressed, 31-34: compressed
+    let flag = signature[0];
+    let (recovery_id, compressed) = match flag {
+        27..=30 => (flag - 27, false),
+        31..=34 => (flag - 31, true),
+        // Also accept raw recovery id (0-3) for compatibility
+        0..=3 => (flag, true),
+        _ => return None,
+    };
+
+    // Rearrange to sp_io format: r[32] || s[32] || recovery_id[1]
+    let mut sig = [0u8; 65];
+    sig[..64].copy_from_slice(&signature[1..65]);
+    sig[64] = recovery_id;
+
+    if compressed {
+        let pubkey = sp_io::crypto::secp256k1_ecdsa_recover_compressed(&sig, message_hash).ok()?;
+        // HASH160 = RIPEMD160(SHA256(compressed_pubkey))
+        // Since we don't have RIPEMD160 in sp_io, we approximate with
+        // SHA256 and take 20 bytes. For production, add a RIPEMD160 crate.
+        // Actually, let's use the full 33-byte compressed pubkey hash.
+        let hash = hash160(&pubkey);
+        Some(BtcPubkeyHash::from_hash160(hash))
+    } else {
+        let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(&sig, message_hash).ok()?;
+        // Uncompressed: 0x04 || x[32] || y[32]
+        let mut uncompressed = [0u8; 65];
+        uncompressed[0] = 0x04;
+        uncompressed[1..].copy_from_slice(&pubkey);
+        let hash = hash160(&uncompressed);
+        Some(BtcPubkeyHash::from_hash160(hash))
+    }
+}
+
+/// Bitcoin HASH160: RIPEMD160(SHA256(data)).
+/// Since `sp_io` doesn't provide RIPEMD160, we use a simplified approach:
+/// take the first 20 bytes of SHA256(SHA256(data)).
+/// NOTE: For full Bitcoin compatibility, a proper RIPEMD160 implementation
+/// should be used. This works for our authentication purposes since both
+/// sides (registration and verification) use the same derivation.
+fn hash160(data: &[u8]) -> [u8; 20] {
+    let hash = sha2_256(&sha2_256(data));
+    let mut result = [0u8; 20];
+    result.copy_from_slice(&hash[..20]);
+    result
+}
+
+#[cfg(feature = "full-crypto")]
+pub trait Sign<Cx> {
+    /// Sign the message with a secp256k1 key, producing a 65-byte BIP-137 signature.
+    fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65];
+}
+
+#[cfg(feature = "full-crypto")]
+impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
+    fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65] {
+        let hash = self.btc_message_hash();
+        let raw_sig = pair.sign_prehashed(&hash);
+        // Convert to BIP-137 format: flag[1] || r[32] || s[32]
+        // Use compressed key flag (31 + recovery_id)
+        let mut btc_sig = [0u8; 65];
+        btc_sig[0] = 31 + raw_sig.0[64]; // compressed flag + recovery_id
+        btc_sig[1..].copy_from_slice(&raw_sig.0[..64]);
+        btc_sig
+    }
+}

--- a/authenticators/bitcoin/src/lib.rs
+++ b/authenticators/bitcoin/src/lib.rs
@@ -1,0 +1,108 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! # Bitcoin Authenticator for Pallet Pass
+//!
+//! Verifies Bitcoin message signatures (BIP-137 compatible), enabling
+//! Bitcoin wallets to authenticate with pallet-pass.
+//!
+//! Uses the standard Bitcoin Signed Message format:
+//! `SHA256d("\x18Bitcoin Signed Message:\n" || varint(len) || message)`
+
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use traits_authn::{AuthorityId, Challenge, DeviceId, HashedUserId};
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[cfg(any(test, feature = "runtime"))]
+mod runtime {
+    use super::*;
+    use traits_authn::{prelude::*, util::*};
+    const LOG_TARGET: &str = "pass_authenticators_bitcoin";
+
+    mod key_registration;
+    mod key_signature;
+
+    type CxOf<Ch> = <Ch as Challenger>::Context;
+    pub type Authenticator<Ch, AuthId> = Auth<Device<Ch, AuthId>, BtcRegistration<CxOf<Ch>>>;
+    pub type Device<Ch, A> = Dev<BtcPubkeyHash, A, Ch, BtcSignature<CxOf<Ch>>>;
+}
+
+#[cfg(any(feature = "runtime", test))]
+pub use runtime::{Authenticator, Device};
+
+mod btc;
+
+/// A Bitcoin public key hash (HASH160 = RIPEMD160(SHA256(pubkey))), stored
+/// in a 32-byte DeviceId-compatible container (left-padded with zeros).
+#[derive(
+    Clone,
+    Copy,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    TypeInfo,
+    MaxEncodedLen,
+    PartialEq,
+    Eq,
+    Debug,
+)]
+pub struct BtcPubkeyHash([u8; 32]);
+
+impl BtcPubkeyHash {
+    /// Create from a raw 20-byte HASH160.
+    pub fn from_hash160(hash: [u8; 20]) -> Self {
+        let mut padded = [0u8; 32];
+        padded[12..].copy_from_slice(&hash);
+        Self(padded)
+    }
+
+    /// Get the raw 20-byte HASH160.
+    pub fn as_hash160(&self) -> &[u8; 20] {
+        self.0[12..].try_into().expect("slice is exactly 20 bytes")
+    }
+}
+
+impl AsRef<DeviceId> for BtcPubkeyHash {
+    fn as_ref(&self) -> &DeviceId {
+        &self.0
+    }
+}
+
+/// A signed message containing the challenge context and authority.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SignedMessage<Cx> {
+    pub context: Cx,
+    pub challenge: Challenge,
+    pub authority_id: AuthorityId,
+}
+
+/// Registration of a Bitcoin public key as a device.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct BtcRegistration<Cx> {
+    pub pubkey_hash: BtcPubkeyHash,
+    pub message: SignedMessage<Cx>,
+    /// 65-byte recoverable signature (recovery_flag[1] || r[32] || s[32])
+    pub signature: [u8; 65],
+}
+
+/// A credential proving the user controls a Bitcoin key.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct BtcSignature<Cx> {
+    pub user_id: HashedUserId,
+    pub message: SignedMessage<Cx>,
+    /// 65-byte recoverable signature (recovery_flag[1] || r[32] || s[32])
+    pub signature: [u8; 65],
+}
+
+#[cfg(feature = "full-crypto")]
+pub use btc::Sign;

--- a/authenticators/bitcoin/src/lib.rs
+++ b/authenticators/bitcoin/src/lib.rs
@@ -103,6 +103,3 @@ pub struct BtcSignature<Cx> {
     /// 65-byte recoverable signature (recovery_flag[1] || r[32] || s[32])
     pub signature: [u8; 65],
 }
-
-#[cfg(feature = "full-crypto")]
-pub use btc::Sign;

--- a/authenticators/bitcoin/src/mock.rs
+++ b/authenticators/bitcoin/src/mock.rs
@@ -1,0 +1,115 @@
+use frame::{
+    deps::sp_runtime::MultiSignature,
+    testing_prelude::*,
+    traits::{EqualPrivilegeOnly, Verify},
+};
+use traits_authn::{
+    util::AuthorityFromPalletId,
+    {Challenger, ExtrinsicContext},
+};
+
+#[frame_construct_runtime]
+pub mod runtime {
+    #[runtime::runtime]
+    #[runtime::derive(
+        RuntimeCall,
+        RuntimeEvent,
+        RuntimeError,
+        RuntimeOrigin,
+        RuntimeTask,
+        RuntimeHoldReason,
+        RuntimeFreezeReason
+    )]
+    pub struct Test;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+    #[runtime::pallet_index(1)]
+    pub type Scheduler = pallet_scheduler;
+    #[runtime::pallet_index(2)]
+    pub type Pass = pallet_pass;
+
+    #[runtime::pallet_index(10)]
+    pub type Balances = pallet_balances;
+}
+
+pub type Block = MockBlock<Test>;
+
+pub type Signature = MultiSignature;
+pub type AccountPublic = <Signature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+
+pub type Balance = <Test as pallet_balances::Config>::Balance;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+    type AccountStore = System;
+}
+
+parameter_types! {
+    pub MaxWeight: Weight = Weight::MAX;
+}
+
+impl pallet_scheduler::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type MaximumWeight = MaxWeight;
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    type OriginPrivilegeCmp = EqualPrivilegeOnly;
+    type MaxScheduledPerBlock = ConstU32<256>;
+    type WeightInfo = ();
+    type Preimages = ();
+    type BlockNumberProvider = System;
+}
+
+parameter_types! {
+    pub PassPalletId: PalletId = PalletId(*b"pass_btc");
+    pub RootAccount: AccountId = AccountId::new([0x0; 32]);
+}
+
+pub type AuthorityId = AuthorityFromPalletId<PassPalletId>;
+
+pub struct BlockChallenger;
+impl Challenger for BlockChallenger {
+    type Context = BlockNumberFor<Test>;
+
+    fn generate(ctx: &Self::Context, xtc: &impl ExtrinsicContext) -> traits_authn::Challenge {
+        <Test as frame_system::Config>::Hashing::hash(&((ctx, xtc.as_ref()).encode())).0
+    }
+}
+
+impl pallet_pass::Config for Test {
+    type PalletsOrigin = OriginCaller;
+    type WeightInfo = ();
+    type RegisterOrigin = EnsureRootWithSuccess<Self::AccountId, RootAccount>;
+    type AddressGenerator = ();
+    type Balances = Balances;
+    type Authenticator = crate::Authenticator<BlockChallenger, AuthorityId>;
+    type Scheduler = Scheduler;
+    type BlockNumberProvider = System;
+    type RegistrarConsideration = ();
+    type DeviceConsideration = ();
+    type SessionKeyConsideration = ();
+    type PalletId = PassPalletId;
+    type MaxDevicesPerAccount = ConstU32<1>;
+    type MaxSessionsPerAccount = ConstU32<1>;
+    type MaxSessionDuration = ConstU64<10>;
+}
+
+pub fn new_test_ext() -> TestExternalities {
+    let mut t = TestExternalities::default();
+    t.execute_with(|| {
+        System::set_block_number(1);
+    });
+    t
+}

--- a/authenticators/bitcoin/src/runtime/key_registration.rs
+++ b/authenticators/bitcoin/src/runtime/key_registration.rs
@@ -1,0 +1,48 @@
+use super::*;
+use crate::btc::recover_btc_pubkey_hash;
+
+impl<Ch: Challenger, AuthId> From<BtcRegistration<CxOf<Ch>>> for Device<Ch, AuthId> {
+    fn from(reg: BtcRegistration<CxOf<Ch>>) -> Self {
+        Self::new(reg.pubkey_hash)
+    }
+}
+
+impl<Cx: Parameter + Encode + 'static> DeviceChallengeResponse<Cx> for BtcRegistration<Cx> {
+    fn is_valid(&self) -> bool {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying Bitcoin registration of {:?}",
+            self.pubkey_hash,
+        );
+        let hash = self.message.btc_message_hash();
+        match recover_btc_pubkey_hash(&hash, &self.signature) {
+            Some(recovered) => {
+                let valid = recovered == self.pubkey_hash;
+                if !valid {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "Pubkey hash mismatch: recovered {:?}, expected {:?}",
+                        recovered, self.pubkey_hash,
+                    );
+                }
+                valid
+            }
+            None => {
+                log::debug!(target: LOG_TARGET, "Failed to recover Bitcoin pubkey hash");
+                false
+            }
+        }
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn device_id(&self) -> &DeviceId {
+        self.pubkey_hash.as_ref()
+    }
+}

--- a/authenticators/bitcoin/src/runtime/key_signature.rs
+++ b/authenticators/bitcoin/src/runtime/key_signature.rs
@@ -1,0 +1,34 @@
+use super::*;
+use crate::btc::recover_btc_pubkey_hash;
+use traits_authn::UserChallengeResponse;
+
+impl<Cx: Parameter + Encode + 'static> UserChallengeResponse<Cx> for BtcSignature<Cx> {
+    fn is_valid(&self) -> bool {
+        true
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn user_id(&self) -> HashedUserId {
+        self.user_id
+    }
+}
+
+impl<Cx: Encode> VerifyCredential<BtcSignature<Cx>> for BtcPubkeyHash {
+    fn verify(&mut self, credential: &BtcSignature<Cx>) -> Option<()> {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying Bitcoin signature for {:?}",
+            self,
+        );
+        let hash = credential.message.btc_message_hash();
+        let recovered = recover_btc_pubkey_hash(&hash, &credential.signature)?;
+        (recovered == *self).then_some(())
+    }
+}

--- a/authenticators/bitcoin/src/tests.rs
+++ b/authenticators/bitcoin/src/tests.rs
@@ -227,4 +227,87 @@ mod btc_signing {
             assert!(recover_btc_pubkey_hash(&hash, &sig).is_none());
         })
     }
+
+    #[test]
+    fn recover_rejects_raw_recovery_id() {
+        new_test_ext().execute_with(|| {
+            let pair = BtcKey::get();
+            let hash = crate::btc::bitcoin_message_hash(b"test");
+            let raw = pair.sign_prehashed(&hash);
+            // Use raw recovery id (0) instead of BIP-137 flag — must be rejected
+            let mut sig = [0u8; 65];
+            sig[0] = 0;
+            sig[1..].copy_from_slice(&raw.0[..64]);
+
+            assert!(recover_btc_pubkey_hash(&hash, &sig).is_none());
+        })
+    }
+
+    #[test]
+    fn recover_works_with_uncompressed_flag() {
+        new_test_ext().execute_with(|| {
+            use ripemd::{Digest, Ripemd160};
+            let pair = BtcKey::get();
+            let hash = crate::btc::bitcoin_message_hash(b"hello uncompressed");
+            let raw = pair.sign_prehashed(&hash);
+
+            // BIP-137 uncompressed format: flag 27 + recovery_id
+            let mut sig = [0u8; 65];
+            sig[0] = 27 + raw.0[64];
+            sig[1..].copy_from_slice(&raw.0[..64]);
+
+            let recovered = recover_btc_pubkey_hash(&hash, &sig).expect("should recover");
+
+            // Derive expected hash from uncompressed pubkey
+            let pubkey_uncompressed = sp_io::crypto::secp256k1_ecdsa_recover(&raw.0, &hash)
+                .ok()
+                .unwrap();
+            let mut full = [0u8; 65];
+            full[0] = 0x04;
+            full[1..].copy_from_slice(&pubkey_uncompressed);
+            let sha = sha2_256(&full);
+            let mut hasher = Ripemd160::new();
+            hasher.update(sha);
+            let expected_h160: [u8; 20] = hasher.finalize().into();
+
+            assert_eq!(recovered, BtcPubkeyHash::from_hash160(expected_h160));
+        })
+    }
+
+    #[test]
+    fn recover_fails_with_zero_signature() {
+        new_test_ext().execute_with(|| {
+            let hash = crate::btc::bitcoin_message_hash(b"test");
+            let sig = [0u8; 65];
+            assert!(recover_btc_pubkey_hash(&hash, &sig).is_none());
+        })
+    }
+
+    #[test]
+    fn recover_accepts_boundary_flags() {
+        new_test_ext().execute_with(|| {
+            let pair = BtcKey::get();
+            let hash = crate::btc::bitcoin_message_hash(b"boundary");
+            let raw = pair.sign_prehashed(&hash);
+
+            // Flag 34 is the maximum valid compressed flag (31 + 3)
+            // Only test if recovery_id <= 3
+            if raw.0[64] <= 1 {
+                let mut sig = [0u8; 65];
+                sig[0] = 31 + raw.0[64]; // Valid compressed flag
+                sig[1..].copy_from_slice(&raw.0[..64]);
+                assert!(recover_btc_pubkey_hash(&hash, &sig).is_some());
+            }
+
+            // Flag 35 must always be rejected
+            let mut sig = [0u8; 65];
+            sig[0] = 35;
+            sig[1..].copy_from_slice(&raw.0[..64]);
+            assert!(recover_btc_pubkey_hash(&hash, &sig).is_none());
+
+            // Flag 26 must be rejected
+            sig[0] = 26;
+            assert!(recover_btc_pubkey_hash(&hash, &sig).is_none());
+        })
+    }
 }

--- a/authenticators/bitcoin/src/tests.rs
+++ b/authenticators/bitcoin/src/tests.rs
@@ -1,0 +1,229 @@
+use crate::mock::*;
+use crate::{
+    btc::recover_btc_pubkey_hash, BtcPubkeyHash, BtcRegistration, BtcSignature, Sign, SignedMessage,
+};
+use frame::{
+    deps::sp_core::{ecdsa, Pair},
+    testing_prelude::*,
+    traits::TxBaseImplication,
+};
+use sp_io::hashing::sha2_256;
+use traits_authn::{Challenger, ExtrinsicContext, HashedUserId};
+
+const USER: HashedUserId = *b"satoshi\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+parameter_types! {
+    pub BtcKey: ecdsa::Pair = ecdsa::Pair::from_seed(&[2u8; 32]);
+    pub UserAddress: AccountId = Pass::address_for(USER);
+}
+
+/// Derive BtcPubkeyHash from a key pair (matching our hash160 implementation).
+fn btc_pubkey_hash_of(pair: &ecdsa::Pair) -> BtcPubkeyHash {
+    let dummy_msg = [0u8; 32];
+    let sig = pair.sign_prehashed(&dummy_msg);
+    let pubkey = sp_io::crypto::secp256k1_ecdsa_recover_compressed(&sig.0, &dummy_msg)
+        .ok()
+        .expect("recovery works");
+    // Our hash160 implementation: first 20 bytes of SHA256(SHA256(data))
+    let hash = sha2_256(&sha2_256(&pubkey));
+    let mut h160 = [0u8; 20];
+    h160.copy_from_slice(&hash[..20]);
+    BtcPubkeyHash::from_hash160(h160)
+}
+
+fn make_signature(xtc: &impl ExtrinsicContext) -> (SignedMessage<u64>, BtcPubkeyHash, [u8; 65]) {
+    let context = System::block_number();
+    let message = SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: AuthorityId::get(),
+    };
+    let pair = BtcKey::get();
+    let pubkey_hash = btc_pubkey_hash_of(&pair);
+    let signature = message.sign(&pair);
+
+    (message, pubkey_hash, signature)
+}
+
+mod registration {
+    use super::*;
+
+    #[test]
+    fn registration_fails_if_attestation_is_invalid() {
+        new_test_ext().execute_with(|| {
+            let (mut message, pubkey_hash, signature) = make_signature(&[]);
+            message.challenge = [0u8; 32];
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    BtcRegistration {
+                        pubkey_hash,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_fails_with_wrong_pubkey_hash() {
+        new_test_ext().execute_with(|| {
+            let (message, _pubkey_hash, signature) = make_signature(&UserAddress::get().encode());
+            let wrong = BtcPubkeyHash::from_hash160([0xAB; 20]);
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    BtcRegistration {
+                        pubkey_hash: wrong,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_works_if_attestation_is_valid() {
+        new_test_ext().execute_with(|| {
+            let (message, pubkey_hash, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                BtcRegistration {
+                    pubkey_hash,
+                    message,
+                    signature,
+                }
+            ));
+        })
+    }
+}
+
+mod authentication {
+    use super::*;
+
+    fn new_test_ext() -> TestExternalities {
+        let mut t = super::new_test_ext();
+        t.execute_with(|| {
+            let (message, pubkey_hash, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                BtcRegistration {
+                    pubkey_hash,
+                    message,
+                    signature,
+                }
+            ));
+        });
+        t
+    }
+
+    #[test]
+    fn authentication_fails_if_credentials_are_invalid() {
+        new_test_ext().execute_with(|| {
+            let (message, pubkey_hash, signature) = make_signature(&[]);
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                pubkey_hash.as_ref().clone(),
+                BtcSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            assert_noop!(
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
+            );
+        })
+    }
+
+    #[test]
+    fn authentication_works_if_credentials_are_valid() {
+        new_test_ext().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            let (message, pubkey_hash, signature) = make_signature(
+                &TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256),
+            );
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                pubkey_hash.as_ref().clone(),
+                BtcSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+        })
+    }
+}
+
+mod btc_signing {
+    use super::*;
+
+    #[test]
+    fn recover_works_with_compressed_flag() {
+        new_test_ext().execute_with(|| {
+            let pair = BtcKey::get();
+            let message = b"hello bitcoin";
+            let hash = crate::btc::bitcoin_message_hash(message);
+            let raw = pair.sign_prehashed(&hash);
+            // BIP-137 compressed format
+            let mut sig = [0u8; 65];
+            sig[0] = 31 + raw.0[64];
+            sig[1..].copy_from_slice(&raw.0[..64]);
+
+            let recovered = recover_btc_pubkey_hash(&hash, &sig).expect("should recover");
+            let expected = btc_pubkey_hash_of(&pair);
+            assert_eq!(recovered, expected);
+        })
+    }
+
+    #[test]
+    fn recover_fails_with_invalid_flag() {
+        new_test_ext().execute_with(|| {
+            let pair = BtcKey::get();
+            let hash = crate::btc::bitcoin_message_hash(b"test");
+            let raw = pair.sign_prehashed(&hash);
+            let mut sig = [0u8; 65];
+            sig[0] = 99; // Invalid flag
+            sig[1..].copy_from_slice(&raw.0[..64]);
+
+            assert!(recover_btc_pubkey_hash(&hash, &sig).is_none());
+        })
+    }
+}

--- a/authenticators/bitcoin/src/tests.rs
+++ b/authenticators/bitcoin/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::mock::*;
 use crate::{
-    btc::recover_btc_pubkey_hash, BtcPubkeyHash, BtcRegistration, BtcSignature, Sign, SignedMessage,
+    btc::recover_btc_pubkey_hash, BtcPubkeyHash, BtcRegistration, BtcSignature, SignedMessage,
 };
 use frame::{
     deps::sp_core::{ecdsa, Pair},

--- a/authenticators/bitcoin/src/tests.rs
+++ b/authenticators/bitcoin/src/tests.rs
@@ -16,17 +16,18 @@ parameter_types! {
     pub UserAddress: AccountId = Pass::address_for(USER);
 }
 
-/// Derive BtcPubkeyHash from a key pair (matching our hash160 implementation).
+/// Derive BtcPubkeyHash from a key pair using real HASH160.
 fn btc_pubkey_hash_of(pair: &ecdsa::Pair) -> BtcPubkeyHash {
+    use ripemd::{Digest, Ripemd160};
     let dummy_msg = [0u8; 32];
     let sig = pair.sign_prehashed(&dummy_msg);
     let pubkey = sp_io::crypto::secp256k1_ecdsa_recover_compressed(&sig.0, &dummy_msg)
         .ok()
         .expect("recovery works");
-    // Our hash160 implementation: first 20 bytes of SHA256(SHA256(data))
-    let hash = sha2_256(&sha2_256(&pubkey));
-    let mut h160 = [0u8; 20];
-    h160.copy_from_slice(&hash[..20]);
+    let sha = sha2_256(&pubkey);
+    let mut hasher = Ripemd160::new();
+    hasher.update(sha);
+    let h160: [u8; 20] = hasher.finalize().into();
     BtcPubkeyHash::from_hash160(h160)
 }
 

--- a/authenticators/ethereum/Cargo.toml
+++ b/authenticators/ethereum/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+name = "pass-authenticators-ethereum"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+codec.workspace = true
+log.workspace = true
+scale-info.workspace = true
+sp-core.workspace = true
+sp-runtime.workspace = true
+traits-authn.workspace = true
+sp-io = { version = "44.0.0", default-features = false }
+
+[dev-dependencies]
+frame.workspace = true
+pallet-balances.workspace = true
+pallet-pass.workspace = true
+pallet-scheduler.workspace = true
+
+[features]
+default = ["std", "runtime", "full-crypto"]
+runtime = []
+full-crypto = ["sp-core/full_crypto"]
+std = [
+  "codec/std",
+  "frame/std",
+  "log/std",
+  "pallet-balances/std",
+  "pallet-pass/std",
+  "pallet-scheduler/std",
+  "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "traits-authn/std",
+]
+try-runtime = [
+  "pallet-pass/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-scheduler/try-runtime",
+  "frame/try-runtime",
+  "sp-runtime/try-runtime",
+]

--- a/authenticators/ethereum/src/eth.rs
+++ b/authenticators/ethereum/src/eth.rs
@@ -4,9 +4,11 @@ use sp_io::hashing::keccak_256;
 extern crate alloc;
 
 impl<Cx: Encode> SignedMessage<Cx> {
-    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    /// The domain-separated payload bytes.
+    /// Prefixed with `b"ETH"` to prevent cross-authenticator signature replay.
     pub fn payload(&self) -> alloc::vec::Vec<u8> {
         [
+            b"ETH".as_slice(),
             self.context.encode().as_ref(),
             &self.challenge[..],
             &self.authority_id[..],

--- a/authenticators/ethereum/src/eth.rs
+++ b/authenticators/ethereum/src/eth.rs
@@ -55,14 +55,9 @@ pub fn recover_eth_address(message_hash: &[u8; 32], signature: &[u8; 65]) -> Opt
 }
 
 #[cfg(feature = "full-crypto")]
-pub trait Sign<Cx> {
+impl<Cx: Encode> SignedMessage<Cx> {
     /// Sign the message with a secp256k1 key, producing a 65-byte Ethereum-style signature.
-    fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65];
-}
-
-#[cfg(feature = "full-crypto")]
-impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
-    fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65] {
+    pub fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65] {
         let hash = self.eth_message_hash();
         pair.sign_prehashed(&hash).0
     }

--- a/authenticators/ethereum/src/eth.rs
+++ b/authenticators/ethereum/src/eth.rs
@@ -1,0 +1,67 @@
+use super::*;
+use sp_io::hashing::keccak_256;
+
+extern crate alloc;
+
+impl<Cx: Encode> SignedMessage<Cx> {
+    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    pub fn payload(&self) -> alloc::vec::Vec<u8> {
+        [
+            self.context.encode().as_ref(),
+            &self.challenge[..],
+            &self.authority_id[..],
+        ]
+        .concat()
+    }
+
+    /// Compute the Ethereum personal_sign message hash.
+    /// Format: keccak256("\x19Ethereum Signed Message:\n" || len || payload)
+    pub fn eth_message_hash(&self) -> [u8; 32] {
+        let payload = self.payload();
+        personal_sign_hash(&payload)
+    }
+}
+
+/// Hash a message using Ethereum's personal_sign format.
+/// `keccak256("\x19Ethereum Signed Message:\n{len}{message}")`
+pub fn personal_sign_hash(message: &[u8]) -> [u8; 32] {
+    let prefix = alloc::format!("\x19Ethereum Signed Message:\n{}", message.len());
+    let mut data = prefix.into_bytes();
+    data.extend_from_slice(message);
+    keccak_256(&data)
+}
+
+/// Recover an Ethereum address from a personal_sign signature.
+pub fn recover_eth_address(message_hash: &[u8; 32], signature: &[u8; 65]) -> Option<EthAddress> {
+    // The signature format is r[32] || s[32] || v[1]
+    let mut sig = [0u8; 65];
+    sig[..64].copy_from_slice(&signature[..64]);
+    // Normalize v: Ethereum uses 27/28, secp256k1 recovery uses 0/1
+    sig[64] = match signature[64] {
+        v @ 0..=1 => v,
+        v @ 27..=28 => v - 27,
+        _ => return None,
+    };
+
+    // Recover uncompressed public key (64 bytes, without 0x04 prefix)
+    let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(&sig, message_hash).ok()?;
+    // Ethereum address = last 20 bytes of keccak256(uncompressed_pubkey)
+    let hash = keccak_256(&pubkey);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    Some(EthAddress::from_raw(addr))
+}
+
+#[cfg(feature = "full-crypto")]
+pub trait Sign<Cx> {
+    /// Sign the message with a secp256k1 key, producing a 65-byte Ethereum-style signature.
+    fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65];
+}
+
+#[cfg(feature = "full-crypto")]
+impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
+    fn sign(&self, pair: &sp_core::ecdsa::Pair) -> [u8; 65] {
+        let hash = self.eth_message_hash();
+        pair.sign_prehashed(&hash).0
+    }
+}

--- a/authenticators/ethereum/src/lib.rs
+++ b/authenticators/ethereum/src/lib.rs
@@ -105,6 +105,3 @@ pub struct EthSignature<Cx> {
     /// 65-byte secp256k1 signature (r[32] || s[32] || v[1])
     pub signature: [u8; 65],
 }
-
-#[cfg(feature = "full-crypto")]
-pub use eth::Sign;

--- a/authenticators/ethereum/src/lib.rs
+++ b/authenticators/ethereum/src/lib.rs
@@ -61,6 +61,11 @@ impl EthAddress {
     pub fn as_eth_bytes(&self) -> &[u8; 20] {
         self.0[12..].try_into().expect("slice is exactly 20 bytes")
     }
+
+    /// Check that the upper 12 padding bytes are zero.
+    pub fn is_well_formed(&self) -> bool {
+        self.0[..12] == [0u8; 12]
+    }
 }
 
 impl AsRef<DeviceId> for EthAddress {

--- a/authenticators/ethereum/src/lib.rs
+++ b/authenticators/ethereum/src/lib.rs
@@ -1,0 +1,105 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! # Ethereum Authenticator for Pallet Pass
+//!
+//! Verifies Ethereum `personal_sign` signatures, enabling MetaMask,
+//! WalletConnect and other EVM wallets to authenticate with pallet-pass.
+
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use traits_authn::{AuthorityId, Challenge, DeviceId, HashedUserId};
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[cfg(any(test, feature = "runtime"))]
+mod runtime {
+    use super::*;
+    use traits_authn::{prelude::*, util::*};
+    const LOG_TARGET: &str = "pass_authenticators_ethereum";
+
+    mod key_registration;
+    mod key_signature;
+
+    type CxOf<Ch> = <Ch as Challenger>::Context;
+    pub type Authenticator<Ch, AuthId> = Auth<Device<Ch, AuthId>, EthRegistration<CxOf<Ch>>>;
+    pub type Device<Ch, A> = Dev<EthAddress, A, Ch, EthSignature<CxOf<Ch>>>;
+}
+
+#[cfg(any(feature = "runtime", test))]
+pub use runtime::{Authenticator, Device};
+
+mod eth;
+
+/// A 20-byte Ethereum address stored in a 32-byte DeviceId-compatible container
+/// (left-padded with 12 zero bytes).
+#[derive(
+    Clone,
+    Copy,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    TypeInfo,
+    MaxEncodedLen,
+    PartialEq,
+    Eq,
+    Debug,
+)]
+pub struct EthAddress([u8; 32]);
+
+impl EthAddress {
+    /// Create from a raw 20-byte Ethereum address.
+    pub fn from_raw(addr: [u8; 20]) -> Self {
+        let mut padded = [0u8; 32];
+        padded[12..].copy_from_slice(&addr);
+        Self(padded)
+    }
+
+    /// Get the raw 20-byte Ethereum address.
+    pub fn as_eth_bytes(&self) -> &[u8; 20] {
+        self.0[12..].try_into().expect("slice is exactly 20 bytes")
+    }
+}
+
+impl AsRef<DeviceId> for EthAddress {
+    fn as_ref(&self) -> &DeviceId {
+        &self.0
+    }
+}
+
+/// A signed message containing the challenge context and authority.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SignedMessage<Cx> {
+    pub context: Cx,
+    pub challenge: Challenge,
+    pub authority_id: AuthorityId,
+}
+
+/// Registration of an Ethereum address as a device.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct EthRegistration<Cx> {
+    pub address: EthAddress,
+    pub message: SignedMessage<Cx>,
+    /// 65-byte secp256k1 signature (r[32] || s[32] || v[1])
+    pub signature: [u8; 65],
+}
+
+/// A credential proving the user controls an Ethereum address.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct EthSignature<Cx> {
+    pub user_id: HashedUserId,
+    pub message: SignedMessage<Cx>,
+    /// 65-byte secp256k1 signature (r[32] || s[32] || v[1])
+    pub signature: [u8; 65],
+}
+
+#[cfg(feature = "full-crypto")]
+pub use eth::Sign;

--- a/authenticators/ethereum/src/mock.rs
+++ b/authenticators/ethereum/src/mock.rs
@@ -1,0 +1,116 @@
+use frame::{
+    deps::sp_runtime::MultiSignature,
+    testing_prelude::*,
+    traits::{EqualPrivilegeOnly, Verify},
+};
+use traits_authn::{
+    util::AuthorityFromPalletId,
+    {Challenger, ExtrinsicContext},
+};
+
+#[frame_construct_runtime]
+pub mod runtime {
+    #[runtime::runtime]
+    #[runtime::derive(
+        RuntimeCall,
+        RuntimeEvent,
+        RuntimeError,
+        RuntimeOrigin,
+        RuntimeTask,
+        RuntimeHoldReason,
+        RuntimeFreezeReason
+    )]
+    pub struct Test;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+    #[runtime::pallet_index(1)]
+    pub type Scheduler = pallet_scheduler;
+    #[runtime::pallet_index(2)]
+    pub type Pass = pallet_pass;
+
+    #[runtime::pallet_index(10)]
+    pub type Balances = pallet_balances;
+}
+
+pub type Block = MockBlock<Test>;
+
+pub type Signature = MultiSignature;
+pub type AccountPublic = <Signature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+
+pub type Balance = <Test as pallet_balances::Config>::Balance;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+    type AccountStore = System;
+}
+
+parameter_types! {
+    pub MaxWeight: Weight = Weight::MAX;
+}
+
+impl pallet_scheduler::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type MaximumWeight = MaxWeight;
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    type OriginPrivilegeCmp = EqualPrivilegeOnly;
+    type MaxScheduledPerBlock = ConstU32<256>;
+    type WeightInfo = ();
+    type Preimages = ();
+    type BlockNumberProvider = System;
+}
+
+parameter_types! {
+    pub PassPalletId: PalletId = PalletId(*b"pass_eth");
+    pub NeverPays: Option<pallet_pass::DepositInformation<Test>> = None;
+    pub RootAccount: AccountId = AccountId::new([0x0; 32]);
+}
+
+pub type AuthorityId = AuthorityFromPalletId<PassPalletId>;
+
+pub struct BlockChallenger;
+impl Challenger for BlockChallenger {
+    type Context = BlockNumberFor<Test>;
+
+    fn generate(ctx: &Self::Context, xtc: &impl ExtrinsicContext) -> traits_authn::Challenge {
+        <Test as frame_system::Config>::Hashing::hash(&((ctx, xtc.as_ref()).encode())).0
+    }
+}
+
+impl pallet_pass::Config for Test {
+    type PalletsOrigin = OriginCaller;
+    type WeightInfo = ();
+    type RegisterOrigin = EnsureRootWithSuccess<Self::AccountId, RootAccount>;
+    type AddressGenerator = ();
+    type Balances = Balances;
+    type Authenticator = crate::Authenticator<BlockChallenger, AuthorityId>;
+    type Scheduler = Scheduler;
+    type BlockNumberProvider = System;
+    type RegistrarConsideration = ();
+    type DeviceConsideration = ();
+    type SessionKeyConsideration = ();
+    type PalletId = PassPalletId;
+    type MaxDevicesPerAccount = ConstU32<1>;
+    type MaxSessionsPerAccount = ConstU32<1>;
+    type MaxSessionDuration = ConstU64<10>;
+}
+
+pub fn new_test_ext() -> TestExternalities {
+    let mut t = TestExternalities::default();
+    t.execute_with(|| {
+        System::set_block_number(1);
+    });
+    t
+}

--- a/authenticators/ethereum/src/runtime/key_registration.rs
+++ b/authenticators/ethereum/src/runtime/key_registration.rs
@@ -9,6 +9,10 @@ impl<Ch: Challenger, AuthId> From<EthRegistration<CxOf<Ch>>> for Device<Ch, Auth
 
 impl<Cx: Parameter + Encode + 'static> DeviceChallengeResponse<Cx> for EthRegistration<Cx> {
     fn is_valid(&self) -> bool {
+        if !self.address.is_well_formed() {
+            log::debug!(target: LOG_TARGET, "Malformed EthAddress: non-zero padding bytes");
+            return false;
+        }
         log::debug!(
             target: LOG_TARGET,
             "Verifying Ethereum registration of {:?} with signature",

--- a/authenticators/ethereum/src/runtime/key_registration.rs
+++ b/authenticators/ethereum/src/runtime/key_registration.rs
@@ -1,0 +1,48 @@
+use super::*;
+use crate::eth::recover_eth_address;
+
+impl<Ch: Challenger, AuthId> From<EthRegistration<CxOf<Ch>>> for Device<Ch, AuthId> {
+    fn from(reg: EthRegistration<CxOf<Ch>>) -> Self {
+        Self::new(reg.address)
+    }
+}
+
+impl<Cx: Parameter + Encode + 'static> DeviceChallengeResponse<Cx> for EthRegistration<Cx> {
+    fn is_valid(&self) -> bool {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying Ethereum registration of {:?} with signature",
+            self.address,
+        );
+        let hash = self.message.eth_message_hash();
+        match recover_eth_address(&hash, &self.signature) {
+            Some(recovered) => {
+                let valid = recovered == self.address;
+                if !valid {
+                    log::debug!(
+                        target: LOG_TARGET,
+                        "Address mismatch: recovered {:?}, expected {:?}",
+                        recovered, self.address,
+                    );
+                }
+                valid
+            }
+            None => {
+                log::debug!(target: LOG_TARGET, "Failed to recover Ethereum address");
+                false
+            }
+        }
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn device_id(&self) -> &DeviceId {
+        self.address.as_ref()
+    }
+}

--- a/authenticators/ethereum/src/runtime/key_signature.rs
+++ b/authenticators/ethereum/src/runtime/key_signature.rs
@@ -23,6 +23,7 @@ impl<Cx: Parameter + Encode + 'static> UserChallengeResponse<Cx> for EthSignatur
 
 impl<Cx: Encode> VerifyCredential<EthSignature<Cx>> for EthAddress {
     fn verify(&mut self, credential: &EthSignature<Cx>) -> Option<()> {
+        self.is_well_formed().then_some(())?;
         log::debug!(
             target: LOG_TARGET,
             "Verifying Ethereum signature for {:?}",

--- a/authenticators/ethereum/src/runtime/key_signature.rs
+++ b/authenticators/ethereum/src/runtime/key_signature.rs
@@ -1,0 +1,35 @@
+use super::*;
+use crate::eth::recover_eth_address;
+use traits_authn::UserChallengeResponse;
+
+impl<Cx: Parameter + Encode + 'static> UserChallengeResponse<Cx> for EthSignature<Cx> {
+    fn is_valid(&self) -> bool {
+        // Signature validation is deferred to the device's verify_credential.
+        true
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn user_id(&self) -> HashedUserId {
+        self.user_id
+    }
+}
+
+impl<Cx: Encode> VerifyCredential<EthSignature<Cx>> for EthAddress {
+    fn verify(&mut self, credential: &EthSignature<Cx>) -> Option<()> {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying Ethereum signature for {:?}",
+            self,
+        );
+        let hash = credential.message.eth_message_hash();
+        let recovered = recover_eth_address(&hash, &credential.signature)?;
+        (recovered == *self).then_some(())
+    }
+}

--- a/authenticators/ethereum/src/tests.rs
+++ b/authenticators/ethereum/src/tests.rs
@@ -1,7 +1,5 @@
 use crate::mock::*;
-use crate::{
-    eth::recover_eth_address, EthAddress, EthRegistration, EthSignature, Sign, SignedMessage,
-};
+use crate::{eth::recover_eth_address, EthAddress, EthRegistration, EthSignature, SignedMessage};
 use frame::{
     deps::sp_core::{ecdsa, Pair},
     testing_prelude::*,

--- a/authenticators/ethereum/src/tests.rs
+++ b/authenticators/ethereum/src/tests.rs
@@ -1,0 +1,242 @@
+use crate::mock::*;
+use crate::{
+    eth::recover_eth_address, EthAddress, EthRegistration, EthSignature, Sign, SignedMessage,
+};
+use frame::{
+    deps::sp_core::{ecdsa, Pair},
+    testing_prelude::*,
+    traits::TxBaseImplication,
+};
+use sp_io::hashing::keccak_256;
+use traits_authn::{Challenger, ExtrinsicContext, HashedUserId};
+
+const USER: HashedUserId = *b"alice\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+parameter_types! {
+    pub EthKey: ecdsa::Pair = ecdsa::Pair::from_seed(&[1u8; 32]);
+    pub UserAddress: AccountId = Pass::address_for(USER);
+}
+
+fn eth_address_of(pair: &ecdsa::Pair) -> EthAddress {
+    let dummy_msg = [0u8; 32];
+    let sig = pair.sign_prehashed(&dummy_msg);
+    let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(&sig.0, &dummy_msg)
+        .ok()
+        .expect("recovery works");
+    let hash = keccak_256(&pubkey);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    EthAddress::from_raw(addr)
+}
+
+fn make_signature(xtc: &impl ExtrinsicContext) -> (SignedMessage<u64>, EthAddress, [u8; 65]) {
+    let context = System::block_number();
+    let message = SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: AuthorityId::get(),
+    };
+    let pair = EthKey::get();
+    let address = eth_address_of(&pair);
+    let signature = message.sign(&pair);
+
+    (message, address, signature)
+}
+
+mod registration {
+    use super::*;
+
+    #[test]
+    fn registration_fails_if_attestation_is_invalid() {
+        new_test_ext().execute_with(|| {
+            let (mut message, address, signature) = make_signature(&[]);
+
+            // Alter challenge to invalidate
+            message.challenge = [0u8; 32];
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    EthRegistration {
+                        address,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_fails_with_wrong_address() {
+        new_test_ext().execute_with(|| {
+            let (message, _address, signature) = make_signature(&UserAddress::get().encode());
+
+            // Use a different address
+            let wrong_address = EthAddress::from_raw([0xAB; 20]);
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    EthRegistration {
+                        address: wrong_address,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_works_if_attestation_is_valid() {
+        new_test_ext().execute_with(|| {
+            let (message, address, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                EthRegistration {
+                    address,
+                    message,
+                    signature,
+                }
+            ));
+        })
+    }
+}
+
+mod authentication {
+    use super::*;
+
+    fn new_test_ext() -> TestExternalities {
+        let mut t = super::new_test_ext();
+        t.execute_with(|| {
+            let (message, address, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                EthRegistration {
+                    address,
+                    message,
+                    signature,
+                }
+            ));
+        });
+        t
+    }
+
+    #[test]
+    fn authentication_fails_if_credentials_are_invalid() {
+        new_test_ext().execute_with(|| {
+            let (message, address, signature) = make_signature(&[]);
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                address.as_ref().clone(),
+                EthSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            assert_noop!(
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
+            );
+        })
+    }
+
+    #[test]
+    fn authentication_works_if_credentials_are_valid() {
+        new_test_ext().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            let (message, address, signature) = make_signature(
+                &TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256),
+            );
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                address.as_ref().clone(),
+                EthSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+        })
+    }
+}
+
+mod eth_address {
+    use super::*;
+
+    #[test]
+    fn recover_works_with_normalized_v() {
+        new_test_ext().execute_with(|| {
+            let pair = EthKey::get();
+            let message = b"hello ethereum";
+            let hash = crate::eth::personal_sign_hash(message);
+            let sig = pair.sign_prehashed(&hash);
+
+            let recovered = recover_eth_address(&hash, &sig.0).expect("should recover");
+            let expected = eth_address_of(&pair);
+            assert_eq!(recovered, expected);
+        })
+    }
+
+    #[test]
+    fn recover_works_with_legacy_v() {
+        new_test_ext().execute_with(|| {
+            let pair = EthKey::get();
+            let message = b"hello ethereum";
+            let hash = crate::eth::personal_sign_hash(message);
+            let mut sig = pair.sign_prehashed(&hash).0;
+
+            // Convert v from 0/1 to legacy 27/28
+            sig[64] += 27;
+
+            let recovered = recover_eth_address(&hash, &sig).expect("should recover");
+            let expected = eth_address_of(&pair);
+            assert_eq!(recovered, expected);
+        })
+    }
+
+    #[test]
+    fn recover_fails_with_invalid_v() {
+        new_test_ext().execute_with(|| {
+            let pair = EthKey::get();
+            let hash = crate::eth::personal_sign_hash(b"test");
+            let mut sig = pair.sign_prehashed(&hash).0;
+            sig[64] = 99; // Invalid v
+
+            assert!(recover_eth_address(&hash, &sig).is_none());
+        })
+    }
+}

--- a/authenticators/ethereum/src/tests.rs
+++ b/authenticators/ethereum/src/tests.rs
@@ -239,4 +239,41 @@ mod eth_address {
             assert!(recover_eth_address(&hash, &sig).is_none());
         })
     }
+
+    #[test]
+    fn recover_fails_with_zero_signature() {
+        new_test_ext().execute_with(|| {
+            let hash = crate::eth::personal_sign_hash(b"test");
+            let sig = [0u8; 65];
+            assert!(recover_eth_address(&hash, &sig).is_none());
+        })
+    }
+
+    #[test]
+    fn malformed_padding_rejects_registration() {
+        new_test_ext().execute_with(|| {
+            let (message, _address, signature) = make_signature(&UserAddress::get().encode());
+
+            // Construct an EthAddress with non-zero padding
+            let mut malformed = EthAddress::from_raw([0xAA; 20]);
+            // Directly set a padding byte to non-zero via encode/decode round-trip
+            let mut bytes = [0u8; 32];
+            bytes[0] = 0xFF; // non-zero in padding area
+            bytes[12..].copy_from_slice(&[0xAA; 20]);
+            let malformed = EthAddress::decode(&mut &bytes[..]).unwrap();
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    EthRegistration {
+                        address: malformed,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
 }

--- a/authenticators/nostr/Cargo.toml
+++ b/authenticators/nostr/Cargo.toml
@@ -1,0 +1,49 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+name = "pass-authenticators-nostr"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+codec.workspace = true
+k256.workspace = true
+log.workspace = true
+scale-info.workspace = true
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+traits-authn.workspace = true
+
+[dev-dependencies]
+frame.workspace = true
+pallet-balances.workspace = true
+pallet-pass.workspace = true
+pallet-scheduler.workspace = true
+
+[features]
+default = ["std", "runtime", "full-crypto"]
+runtime = []
+full-crypto = ["sp-core/full_crypto", "k256/arithmetic"]
+std = [
+  "codec/std",
+  "frame/std",
+  "k256/std",
+  "log/std",
+  "pallet-balances/std",
+  "pallet-pass/std",
+  "pallet-scheduler/std",
+  "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "traits-authn/std",
+]
+try-runtime = [
+  "pallet-pass/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-scheduler/try-runtime",
+  "frame/try-runtime",
+  "sp-runtime/try-runtime",
+]

--- a/authenticators/nostr/src/lib.rs
+++ b/authenticators/nostr/src/lib.rs
@@ -1,0 +1,90 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! # Nostr Authenticator for Pallet Pass
+//!
+//! Verifies BIP-340 Schnorr signatures over secp256k1, enabling
+//! Nostr clients (NIP-07 compatible) to authenticate with pallet-pass.
+
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use traits_authn::{AuthorityId, Challenge, DeviceId, HashedUserId};
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[cfg(any(test, feature = "runtime"))]
+mod runtime {
+    use super::*;
+    use traits_authn::{prelude::*, util::*};
+    const LOG_TARGET: &str = "pass_authenticators_nostr";
+
+    mod key_registration;
+    mod key_signature;
+
+    type CxOf<Ch> = <Ch as Challenger>::Context;
+    pub type Authenticator<Ch, AuthId> = Auth<Device<Ch, AuthId>, NostrRegistration<CxOf<Ch>>>;
+    pub type Device<Ch, A> = Dev<NostrPubkey, A, Ch, NostrSignature<CxOf<Ch>>>;
+}
+
+#[cfg(any(feature = "runtime", test))]
+pub use runtime::{Authenticator, Device};
+
+mod schnorr;
+
+/// A 32-byte x-only secp256k1 public key (Nostr npub).
+#[derive(
+    Clone,
+    Copy,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    TypeInfo,
+    MaxEncodedLen,
+    PartialEq,
+    Eq,
+    Debug,
+)]
+pub struct NostrPubkey(pub [u8; 32]);
+
+impl AsRef<DeviceId> for NostrPubkey {
+    fn as_ref(&self) -> &DeviceId {
+        &self.0
+    }
+}
+
+/// A signed message containing the challenge context and authority.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SignedMessage<Cx> {
+    pub context: Cx,
+    pub challenge: Challenge,
+    pub authority_id: AuthorityId,
+}
+
+/// Registration of a Nostr public key as a device.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct NostrRegistration<Cx> {
+    pub pubkey: NostrPubkey,
+    pub message: SignedMessage<Cx>,
+    /// 64-byte BIP-340 Schnorr signature
+    pub signature: [u8; 64],
+}
+
+/// A credential proving the user controls a Nostr key.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct NostrSignature<Cx> {
+    pub user_id: HashedUserId,
+    pub message: SignedMessage<Cx>,
+    /// 64-byte BIP-340 Schnorr signature
+    pub signature: [u8; 64],
+}
+
+#[cfg(feature = "full-crypto")]
+pub use schnorr::Sign;

--- a/authenticators/nostr/src/lib.rs
+++ b/authenticators/nostr/src/lib.rs
@@ -85,6 +85,3 @@ pub struct NostrSignature<Cx> {
     /// 64-byte BIP-340 Schnorr signature
     pub signature: [u8; 64],
 }
-
-#[cfg(feature = "full-crypto")]
-pub use schnorr::Sign;

--- a/authenticators/nostr/src/mock.rs
+++ b/authenticators/nostr/src/mock.rs
@@ -1,0 +1,115 @@
+use frame::{
+    deps::sp_runtime::MultiSignature,
+    testing_prelude::*,
+    traits::{EqualPrivilegeOnly, Verify},
+};
+use traits_authn::{
+    util::AuthorityFromPalletId,
+    {Challenger, ExtrinsicContext},
+};
+
+#[frame_construct_runtime]
+pub mod runtime {
+    #[runtime::runtime]
+    #[runtime::derive(
+        RuntimeCall,
+        RuntimeEvent,
+        RuntimeError,
+        RuntimeOrigin,
+        RuntimeTask,
+        RuntimeHoldReason,
+        RuntimeFreezeReason
+    )]
+    pub struct Test;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+    #[runtime::pallet_index(1)]
+    pub type Scheduler = pallet_scheduler;
+    #[runtime::pallet_index(2)]
+    pub type Pass = pallet_pass;
+
+    #[runtime::pallet_index(10)]
+    pub type Balances = pallet_balances;
+}
+
+pub type Block = MockBlock<Test>;
+
+pub type Signature = MultiSignature;
+pub type AccountPublic = <Signature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+
+pub type Balance = <Test as pallet_balances::Config>::Balance;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+    type AccountStore = System;
+}
+
+parameter_types! {
+    pub MaxWeight: Weight = Weight::MAX;
+}
+
+impl pallet_scheduler::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type MaximumWeight = MaxWeight;
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    type OriginPrivilegeCmp = EqualPrivilegeOnly;
+    type MaxScheduledPerBlock = ConstU32<256>;
+    type WeightInfo = ();
+    type Preimages = ();
+    type BlockNumberProvider = System;
+}
+
+parameter_types! {
+    pub PassPalletId: PalletId = PalletId(*b"pass_nos");
+    pub RootAccount: AccountId = AccountId::new([0x0; 32]);
+}
+
+pub type AuthorityId = AuthorityFromPalletId<PassPalletId>;
+
+pub struct BlockChallenger;
+impl Challenger for BlockChallenger {
+    type Context = BlockNumberFor<Test>;
+
+    fn generate(ctx: &Self::Context, xtc: &impl ExtrinsicContext) -> traits_authn::Challenge {
+        <Test as frame_system::Config>::Hashing::hash(&((ctx, xtc.as_ref()).encode())).0
+    }
+}
+
+impl pallet_pass::Config for Test {
+    type PalletsOrigin = OriginCaller;
+    type WeightInfo = ();
+    type RegisterOrigin = EnsureRootWithSuccess<Self::AccountId, RootAccount>;
+    type AddressGenerator = ();
+    type Balances = Balances;
+    type Authenticator = crate::Authenticator<BlockChallenger, AuthorityId>;
+    type Scheduler = Scheduler;
+    type BlockNumberProvider = System;
+    type RegistrarConsideration = ();
+    type DeviceConsideration = ();
+    type SessionKeyConsideration = ();
+    type PalletId = PassPalletId;
+    type MaxDevicesPerAccount = ConstU32<1>;
+    type MaxSessionsPerAccount = ConstU32<1>;
+    type MaxSessionDuration = ConstU64<10>;
+}
+
+pub fn new_test_ext() -> TestExternalities {
+    let mut t = TestExternalities::default();
+    t.execute_with(|| {
+        System::set_block_number(1);
+    });
+    t
+}

--- a/authenticators/nostr/src/runtime/key_registration.rs
+++ b/authenticators/nostr/src/runtime/key_registration.rs
@@ -1,0 +1,32 @@
+use super::*;
+use crate::schnorr::verify_schnorr;
+
+impl<Ch: Challenger, AuthId> From<NostrRegistration<CxOf<Ch>>> for Device<Ch, AuthId> {
+    fn from(reg: NostrRegistration<CxOf<Ch>>) -> Self {
+        Self::new(reg.pubkey)
+    }
+}
+
+impl<Cx: Parameter + Encode + 'static> DeviceChallengeResponse<Cx> for NostrRegistration<Cx> {
+    fn is_valid(&self) -> bool {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying Nostr registration of {:?}",
+            self.pubkey,
+        );
+        let hash = self.message.message_hash();
+        verify_schnorr(&self.pubkey, &hash, &self.signature)
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn device_id(&self) -> &DeviceId {
+        self.pubkey.as_ref()
+    }
+}

--- a/authenticators/nostr/src/runtime/key_signature.rs
+++ b/authenticators/nostr/src/runtime/key_signature.rs
@@ -1,0 +1,33 @@
+use super::*;
+use crate::schnorr::verify_schnorr;
+use traits_authn::UserChallengeResponse;
+
+impl<Cx: Parameter + Encode + 'static> UserChallengeResponse<Cx> for NostrSignature<Cx> {
+    fn is_valid(&self) -> bool {
+        true
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn user_id(&self) -> HashedUserId {
+        self.user_id
+    }
+}
+
+impl<Cx: Encode> VerifyCredential<NostrSignature<Cx>> for NostrPubkey {
+    fn verify(&mut self, credential: &NostrSignature<Cx>) -> Option<()> {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying Nostr signature for {:?}",
+            self,
+        );
+        let hash = credential.message.message_hash();
+        verify_schnorr(self, &hash, &credential.signature).then_some(())
+    }
+}

--- a/authenticators/nostr/src/schnorr.rs
+++ b/authenticators/nostr/src/schnorr.rs
@@ -1,0 +1,54 @@
+use super::*;
+use k256::schnorr::signature::hazmat::PrehashVerifier;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+impl<Cx: Encode> SignedMessage<Cx> {
+    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    pub fn payload(&self) -> Vec<u8> {
+        [
+            self.context.encode().as_ref(),
+            &self.challenge[..],
+            &self.authority_id[..],
+        ]
+        .concat()
+    }
+
+    /// Compute the BIP-340 tagged hash for signing.
+    /// Uses SHA256 of the raw payload (Nostr signs message hashes).
+    pub fn message_hash(&self) -> [u8; 32] {
+        let payload = self.payload();
+        sp_io::hashing::sha2_256(&payload)
+    }
+}
+
+/// Verify a BIP-340 Schnorr signature against a Nostr x-only public key.
+pub fn verify_schnorr(pubkey: &NostrPubkey, message_hash: &[u8; 32], signature: &[u8; 64]) -> bool {
+    let Ok(vk) = k256::schnorr::VerifyingKey::from_bytes(&pubkey.0) else {
+        return false;
+    };
+    let Ok(sig) = k256::schnorr::Signature::try_from(signature.as_slice()) else {
+        return false;
+    };
+    vk.verify_prehash(message_hash, &sig).is_ok()
+}
+
+#[cfg(feature = "full-crypto")]
+pub trait Sign<Cx> {
+    /// Sign the message hash with a BIP-340 Schnorr signing key.
+    fn sign(&self, signing_key: &k256::schnorr::SigningKey) -> [u8; 64];
+}
+
+#[cfg(feature = "full-crypto")]
+impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
+    fn sign(&self, signing_key: &k256::schnorr::SigningKey) -> [u8; 64] {
+        use k256::schnorr::signature::hazmat::PrehashSigner;
+        let hash = self.message_hash();
+        let sig: k256::schnorr::Signature = signing_key
+            .sign_prehash(&hash)
+            .expect("signing should not fail");
+        let bytes: [u8; 64] = sig.to_bytes().into();
+        bytes
+    }
+}

--- a/authenticators/nostr/src/schnorr.rs
+++ b/authenticators/nostr/src/schnorr.rs
@@ -51,20 +51,14 @@ pub fn verify_schnorr(pubkey: &NostrPubkey, message_hash: &[u8; 32], signature: 
 }
 
 #[cfg(feature = "full-crypto")]
-pub trait Sign<Cx> {
+impl<Cx: Encode> SignedMessage<Cx> {
     /// Sign the BIP-340 tagged message hash with a Schnorr signing key.
-    fn sign(&self, signing_key: &k256::schnorr::SigningKey) -> [u8; 64];
-}
-
-#[cfg(feature = "full-crypto")]
-impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
-    fn sign(&self, signing_key: &k256::schnorr::SigningKey) -> [u8; 64] {
+    pub fn sign(&self, signing_key: &k256::schnorr::SigningKey) -> [u8; 64] {
         use k256::schnorr::signature::hazmat::PrehashSigner;
         let hash = self.message_hash();
         let sig: k256::schnorr::Signature = signing_key
             .sign_prehash(&hash)
             .expect("signing should not fail");
-        let bytes: [u8; 64] = sig.to_bytes().into();
-        bytes
+        sig.to_bytes().into()
     }
 }

--- a/authenticators/nostr/src/schnorr.rs
+++ b/authenticators/nostr/src/schnorr.rs
@@ -4,10 +4,15 @@ use k256::schnorr::signature::hazmat::PrehashVerifier;
 extern crate alloc;
 use alloc::vec::Vec;
 
+/// BIP-340 tag for our Nostr authenticator's tagged hash.
+const BIP340_TAG: &[u8] = b"pallet-pass/nostr";
+
 impl<Cx: Encode> SignedMessage<Cx> {
-    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    /// The domain-separated payload bytes.
+    /// Prefixed with `b"NOSTR"` to prevent cross-authenticator signature replay.
     pub fn payload(&self) -> Vec<u8> {
         [
+            b"NOSTR".as_slice(),
             self.context.encode().as_ref(),
             &self.challenge[..],
             &self.authority_id[..],
@@ -15,12 +20,23 @@ impl<Cx: Encode> SignedMessage<Cx> {
         .concat()
     }
 
-    /// Compute the BIP-340 tagged hash for signing.
-    /// Uses SHA256 of the raw payload (Nostr signs message hashes).
+    /// Compute a BIP-340 tagged hash of the payload.
+    /// Format: `SHA256(SHA256(tag) || SHA256(tag) || msg)`
+    /// where tag = `b"pallet-pass/nostr"` and msg = payload bytes.
     pub fn message_hash(&self) -> [u8; 32] {
         let payload = self.payload();
-        sp_io::hashing::sha2_256(&payload)
+        bip340_tagged_hash(BIP340_TAG, &payload)
     }
+}
+
+/// Compute a BIP-340 tagged hash: `SHA256(SHA256(tag) || SHA256(tag) || msg)`.
+fn bip340_tagged_hash(tag: &[u8], msg: &[u8]) -> [u8; 32] {
+    let tag_hash = sp_io::hashing::sha2_256(tag);
+    let mut data = Vec::with_capacity(64 + msg.len());
+    data.extend_from_slice(&tag_hash);
+    data.extend_from_slice(&tag_hash);
+    data.extend_from_slice(msg);
+    sp_io::hashing::sha2_256(&data)
 }
 
 /// Verify a BIP-340 Schnorr signature against a Nostr x-only public key.
@@ -36,7 +52,7 @@ pub fn verify_schnorr(pubkey: &NostrPubkey, message_hash: &[u8; 32], signature: 
 
 #[cfg(feature = "full-crypto")]
 pub trait Sign<Cx> {
-    /// Sign the message hash with a BIP-340 Schnorr signing key.
+    /// Sign the BIP-340 tagged message hash with a Schnorr signing key.
     fn sign(&self, signing_key: &k256::schnorr::SigningKey) -> [u8; 64];
 }
 

--- a/authenticators/nostr/src/tests.rs
+++ b/authenticators/nostr/src/tests.rs
@@ -216,4 +216,45 @@ mod schnorr_verification {
             ));
         })
     }
+
+    #[test]
+    fn verify_fails_with_invalid_pubkey_not_on_curve() {
+        new_test_ext().execute_with(|| {
+            // All-zeros is not a valid x-only point
+            let bad_pubkey = NostrPubkey([0u8; 32]);
+            let msg_hash = [0u8; 32];
+            let sig = [0u8; 64];
+            assert!(!crate::schnorr::verify_schnorr(
+                &bad_pubkey,
+                &msg_hash,
+                &sig
+            ));
+        })
+    }
+
+    #[test]
+    fn verify_fails_with_zero_signature() {
+        new_test_ext().execute_with(|| {
+            let (_sk, pubkey) = nostr_keypair();
+            let msg_hash = sp_io::hashing::sha2_256(b"test");
+            let sig = [0u8; 64];
+            assert!(!crate::schnorr::verify_schnorr(&pubkey, &msg_hash, &sig));
+        })
+    }
+
+    #[test]
+    fn verify_fails_with_bit_flipped_signature() {
+        new_test_ext().execute_with(|| {
+            let (sk, pubkey) = nostr_keypair();
+            let msg_hash = sp_io::hashing::sha2_256(b"tampered");
+            use k256::schnorr::signature::hazmat::PrehashSigner;
+            let sig: k256::schnorr::Signature = sk.sign_prehash(&msg_hash).expect("sign ok");
+            let mut sig_bytes: [u8; 64] = sig.to_bytes().into();
+            sig_bytes[0] ^= 0x01; // Flip one bit
+
+            assert!(!crate::schnorr::verify_schnorr(
+                &pubkey, &msg_hash, &sig_bytes
+            ));
+        })
+    }
 }

--- a/authenticators/nostr/src/tests.rs
+++ b/authenticators/nostr/src/tests.rs
@@ -1,0 +1,219 @@
+use crate::mock::*;
+use crate::{NostrPubkey, NostrRegistration, NostrSignature, Sign, SignedMessage};
+use frame::testing_prelude::*;
+use frame::traits::TxBaseImplication;
+use traits_authn::{Challenger, ExtrinsicContext, HashedUserId};
+
+const USER: HashedUserId = *b"nostr_user\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+parameter_types! {
+    pub UserAddress: AccountId = Pass::address_for(USER);
+}
+
+fn nostr_keypair() -> (k256::schnorr::SigningKey, NostrPubkey) {
+    let sk = k256::schnorr::SigningKey::from_bytes(&[4u8; 32]).expect("valid key");
+    let vk = sk.verifying_key();
+    let pubkey = NostrPubkey(vk.to_bytes().into());
+    (sk, pubkey)
+}
+
+fn make_signature(xtc: &impl ExtrinsicContext) -> (SignedMessage<u64>, NostrPubkey, [u8; 64]) {
+    let context = System::block_number();
+    let message = SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: AuthorityId::get(),
+    };
+    let (sk, pubkey) = nostr_keypair();
+    let signature = message.sign(&sk);
+
+    (message, pubkey, signature)
+}
+
+mod registration {
+    use super::*;
+
+    #[test]
+    fn registration_fails_if_attestation_is_invalid() {
+        new_test_ext().execute_with(|| {
+            let (mut message, pubkey, signature) = make_signature(&[]);
+            message.challenge = [0u8; 32];
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    NostrRegistration {
+                        pubkey,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_fails_with_wrong_pubkey() {
+        new_test_ext().execute_with(|| {
+            let (message, _pubkey, signature) = make_signature(&UserAddress::get().encode());
+            // Use a different key's pubkey
+            let other_sk = k256::schnorr::SigningKey::from_bytes(&[5u8; 32]).expect("valid key");
+            let wrong = NostrPubkey(other_sk.verifying_key().to_bytes().into());
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    NostrRegistration {
+                        pubkey: wrong,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_works_if_attestation_is_valid() {
+        new_test_ext().execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                NostrRegistration {
+                    pubkey,
+                    message,
+                    signature,
+                }
+            ));
+        })
+    }
+}
+
+mod authentication {
+    use super::*;
+
+    fn new_test_ext() -> TestExternalities {
+        let mut t = super::new_test_ext();
+        t.execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                NostrRegistration {
+                    pubkey,
+                    message,
+                    signature,
+                }
+            ));
+        });
+        t
+    }
+
+    #[test]
+    fn authentication_fails_if_credentials_are_invalid() {
+        new_test_ext().execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&[]);
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                pubkey.as_ref().clone(),
+                NostrSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            assert_noop!(
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
+            );
+        })
+    }
+
+    #[test]
+    fn authentication_works_if_credentials_are_valid() {
+        new_test_ext().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            let (message, pubkey, signature) = make_signature(
+                &TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256),
+            );
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                pubkey.as_ref().clone(),
+                NostrSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+        })
+    }
+}
+
+mod schnorr_verification {
+    use super::*;
+
+    #[test]
+    fn verify_works_with_valid_signature() {
+        new_test_ext().execute_with(|| {
+            let (sk, pubkey) = nostr_keypair();
+            let msg_hash = sp_io::hashing::sha2_256(b"hello nostr");
+            use k256::schnorr::signature::hazmat::PrehashSigner;
+            let sig: k256::schnorr::Signature = sk.sign_prehash(&msg_hash).expect("sign ok");
+            let sig_bytes: [u8; 64] = sig.to_bytes().into();
+
+            assert!(crate::schnorr::verify_schnorr(
+                &pubkey, &msg_hash, &sig_bytes
+            ));
+        })
+    }
+
+    #[test]
+    fn verify_fails_with_wrong_pubkey() {
+        new_test_ext().execute_with(|| {
+            let (sk, _pubkey) = nostr_keypair();
+            let other_sk = k256::schnorr::SigningKey::from_bytes(&[5u8; 32]).expect("valid key");
+            let wrong_pubkey = NostrPubkey(other_sk.verifying_key().to_bytes().into());
+
+            let msg_hash = sp_io::hashing::sha2_256(b"hello nostr");
+            use k256::schnorr::signature::hazmat::PrehashSigner;
+            let sig: k256::schnorr::Signature = sk.sign_prehash(&msg_hash).expect("sign ok");
+            let sig_bytes: [u8; 64] = sig.to_bytes().into();
+
+            assert!(!crate::schnorr::verify_schnorr(
+                &wrong_pubkey,
+                &msg_hash,
+                &sig_bytes
+            ));
+        })
+    }
+}

--- a/authenticators/nostr/src/tests.rs
+++ b/authenticators/nostr/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::mock::*;
-use crate::{NostrPubkey, NostrRegistration, NostrSignature, Sign, SignedMessage};
+use crate::{NostrPubkey, NostrRegistration, NostrSignature, SignedMessage};
 use frame::testing_prelude::*;
 use frame::traits::TxBaseImplication;
 use traits_authn::{Challenger, ExtrinsicContext, HashedUserId};

--- a/authenticators/solana/Cargo.toml
+++ b/authenticators/solana/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+name = "pass-authenticators-solana"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+codec.workspace = true
+log.workspace = true
+scale-info.workspace = true
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+traits-authn.workspace = true
+
+[dev-dependencies]
+frame.workspace = true
+pallet-balances.workspace = true
+pallet-pass.workspace = true
+pallet-scheduler.workspace = true
+
+[features]
+default = ["std", "runtime", "full-crypto"]
+runtime = []
+full-crypto = ["sp-core/full_crypto"]
+std = [
+  "codec/std",
+  "frame/std",
+  "log/std",
+  "pallet-balances/std",
+  "pallet-pass/std",
+  "pallet-scheduler/std",
+  "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "traits-authn/std",
+]
+try-runtime = [
+  "pallet-pass/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-scheduler/try-runtime",
+  "frame/try-runtime",
+  "sp-runtime/try-runtime",
+]

--- a/authenticators/solana/src/lib.rs
+++ b/authenticators/solana/src/lib.rs
@@ -85,6 +85,3 @@ pub struct SolSignature<Cx> {
     /// 64-byte Ed25519 signature
     pub signature: [u8; 64],
 }
-
-#[cfg(feature = "full-crypto")]
-pub use sol::Sign;

--- a/authenticators/solana/src/lib.rs
+++ b/authenticators/solana/src/lib.rs
@@ -1,0 +1,90 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! # Solana Authenticator for Pallet Pass
+//!
+//! Verifies Ed25519 signatures from Solana wallets (Phantom, Solflare, etc.).
+//! Solana wallets sign raw message bytes directly using Ed25519.
+
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use traits_authn::{AuthorityId, Challenge, DeviceId, HashedUserId};
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[cfg(any(test, feature = "runtime"))]
+mod runtime {
+    use super::*;
+    use traits_authn::{prelude::*, util::*};
+    const LOG_TARGET: &str = "pass_authenticators_solana";
+
+    mod key_registration;
+    mod key_signature;
+
+    type CxOf<Ch> = <Ch as Challenger>::Context;
+    pub type Authenticator<Ch, AuthId> = Auth<Device<Ch, AuthId>, SolRegistration<CxOf<Ch>>>;
+    pub type Device<Ch, A> = Dev<SolPubkey, A, Ch, SolSignature<CxOf<Ch>>>;
+}
+
+#[cfg(any(feature = "runtime", test))]
+pub use runtime::{Authenticator, Device};
+
+mod sol;
+
+/// A 32-byte Ed25519 public key (Solana address).
+#[derive(
+    Clone,
+    Copy,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    TypeInfo,
+    MaxEncodedLen,
+    PartialEq,
+    Eq,
+    Debug,
+)]
+pub struct SolPubkey(pub [u8; 32]);
+
+impl AsRef<DeviceId> for SolPubkey {
+    fn as_ref(&self) -> &DeviceId {
+        &self.0
+    }
+}
+
+/// A signed message containing the challenge context and authority.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SignedMessage<Cx> {
+    pub context: Cx,
+    pub challenge: Challenge,
+    pub authority_id: AuthorityId,
+}
+
+/// Registration of a Solana public key as a device.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SolRegistration<Cx> {
+    pub pubkey: SolPubkey,
+    pub message: SignedMessage<Cx>,
+    /// 64-byte Ed25519 signature
+    pub signature: [u8; 64],
+}
+
+/// A credential proving the user controls a Solana key.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SolSignature<Cx> {
+    pub user_id: HashedUserId,
+    pub message: SignedMessage<Cx>,
+    /// 64-byte Ed25519 signature
+    pub signature: [u8; 64],
+}
+
+#[cfg(feature = "full-crypto")]
+pub use sol::Sign;

--- a/authenticators/solana/src/mock.rs
+++ b/authenticators/solana/src/mock.rs
@@ -1,0 +1,115 @@
+use frame::{
+    deps::sp_runtime::MultiSignature,
+    testing_prelude::*,
+    traits::{EqualPrivilegeOnly, Verify},
+};
+use traits_authn::{
+    util::AuthorityFromPalletId,
+    {Challenger, ExtrinsicContext},
+};
+
+#[frame_construct_runtime]
+pub mod runtime {
+    #[runtime::runtime]
+    #[runtime::derive(
+        RuntimeCall,
+        RuntimeEvent,
+        RuntimeError,
+        RuntimeOrigin,
+        RuntimeTask,
+        RuntimeHoldReason,
+        RuntimeFreezeReason
+    )]
+    pub struct Test;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+    #[runtime::pallet_index(1)]
+    pub type Scheduler = pallet_scheduler;
+    #[runtime::pallet_index(2)]
+    pub type Pass = pallet_pass;
+
+    #[runtime::pallet_index(10)]
+    pub type Balances = pallet_balances;
+}
+
+pub type Block = MockBlock<Test>;
+
+pub type Signature = MultiSignature;
+pub type AccountPublic = <Signature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+
+pub type Balance = <Test as pallet_balances::Config>::Balance;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+    type AccountStore = System;
+}
+
+parameter_types! {
+    pub MaxWeight: Weight = Weight::MAX;
+}
+
+impl pallet_scheduler::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type MaximumWeight = MaxWeight;
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    type OriginPrivilegeCmp = EqualPrivilegeOnly;
+    type MaxScheduledPerBlock = ConstU32<256>;
+    type WeightInfo = ();
+    type Preimages = ();
+    type BlockNumberProvider = System;
+}
+
+parameter_types! {
+    pub PassPalletId: PalletId = PalletId(*b"pass_sol");
+    pub RootAccount: AccountId = AccountId::new([0x0; 32]);
+}
+
+pub type AuthorityId = AuthorityFromPalletId<PassPalletId>;
+
+pub struct BlockChallenger;
+impl Challenger for BlockChallenger {
+    type Context = BlockNumberFor<Test>;
+
+    fn generate(ctx: &Self::Context, xtc: &impl ExtrinsicContext) -> traits_authn::Challenge {
+        <Test as frame_system::Config>::Hashing::hash(&((ctx, xtc.as_ref()).encode())).0
+    }
+}
+
+impl pallet_pass::Config for Test {
+    type PalletsOrigin = OriginCaller;
+    type WeightInfo = ();
+    type RegisterOrigin = EnsureRootWithSuccess<Self::AccountId, RootAccount>;
+    type AddressGenerator = ();
+    type Balances = Balances;
+    type Authenticator = crate::Authenticator<BlockChallenger, AuthorityId>;
+    type Scheduler = Scheduler;
+    type BlockNumberProvider = System;
+    type RegistrarConsideration = ();
+    type DeviceConsideration = ();
+    type SessionKeyConsideration = ();
+    type PalletId = PassPalletId;
+    type MaxDevicesPerAccount = ConstU32<1>;
+    type MaxSessionsPerAccount = ConstU32<1>;
+    type MaxSessionDuration = ConstU64<10>;
+}
+
+pub fn new_test_ext() -> TestExternalities {
+    let mut t = TestExternalities::default();
+    t.execute_with(|| {
+        System::set_block_number(1);
+    });
+    t
+}

--- a/authenticators/solana/src/runtime/key_registration.rs
+++ b/authenticators/solana/src/runtime/key_registration.rs
@@ -1,0 +1,32 @@
+use super::*;
+use crate::sol::verify_ed25519;
+
+impl<Ch: Challenger, AuthId> From<SolRegistration<CxOf<Ch>>> for Device<Ch, AuthId> {
+    fn from(reg: SolRegistration<CxOf<Ch>>) -> Self {
+        Self::new(reg.pubkey)
+    }
+}
+
+impl<Cx: Parameter + Encode + 'static> DeviceChallengeResponse<Cx> for SolRegistration<Cx> {
+    fn is_valid(&self) -> bool {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying Solana registration of {:?}",
+            self.pubkey,
+        );
+        let payload = self.message.payload();
+        verify_ed25519(&self.pubkey, &payload, &self.signature)
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn device_id(&self) -> &DeviceId {
+        self.pubkey.as_ref()
+    }
+}

--- a/authenticators/solana/src/runtime/key_signature.rs
+++ b/authenticators/solana/src/runtime/key_signature.rs
@@ -1,0 +1,33 @@
+use super::*;
+use crate::sol::verify_ed25519;
+use traits_authn::UserChallengeResponse;
+
+impl<Cx: Parameter + Encode + 'static> UserChallengeResponse<Cx> for SolSignature<Cx> {
+    fn is_valid(&self) -> bool {
+        true
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn user_id(&self) -> HashedUserId {
+        self.user_id
+    }
+}
+
+impl<Cx: Encode> VerifyCredential<SolSignature<Cx>> for SolPubkey {
+    fn verify(&mut self, credential: &SolSignature<Cx>) -> Option<()> {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying Solana signature for {:?}",
+            self,
+        );
+        let payload = credential.message.payload();
+        verify_ed25519(self, &payload, &credential.signature).then_some(())
+    }
+}

--- a/authenticators/solana/src/sol.rs
+++ b/authenticators/solana/src/sol.rs
@@ -1,0 +1,40 @@
+use super::*;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+impl<Cx: Encode> SignedMessage<Cx> {
+    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    /// Solana wallets sign raw bytes directly, no special prefix.
+    pub fn payload(&self) -> Vec<u8> {
+        [
+            self.context.encode().as_ref(),
+            &self.challenge[..],
+            &self.authority_id[..],
+        ]
+        .concat()
+    }
+}
+
+/// Verify an Ed25519 signature against a Solana public key.
+pub fn verify_ed25519(pubkey: &SolPubkey, message: &[u8], signature: &[u8; 64]) -> bool {
+    // Use sp_io's ed25519 verification
+    let ed_pub = sp_core::ed25519::Public::from_raw(pubkey.0);
+    let ed_sig = sp_core::ed25519::Signature::from_raw(*signature);
+    sp_io::crypto::ed25519_verify(&ed_sig, message, &ed_pub)
+}
+
+#[cfg(feature = "full-crypto")]
+pub trait Sign<Cx> {
+    /// Sign the message payload with an Ed25519 key pair.
+    fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64];
+}
+
+#[cfg(feature = "full-crypto")]
+impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
+    fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64] {
+        use sp_core::Pair;
+        let payload = self.payload();
+        pair.sign(&payload).0
+    }
+}

--- a/authenticators/solana/src/sol.rs
+++ b/authenticators/solana/src/sol.rs
@@ -4,10 +4,11 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 impl<Cx: Encode> SignedMessage<Cx> {
-    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
-    /// Solana wallets sign raw bytes directly, no special prefix.
+    /// The domain-separated payload bytes.
+    /// Prefixed with `b"SOL"` to prevent cross-authenticator signature replay.
     pub fn payload(&self) -> Vec<u8> {
         [
+            b"SOL".as_slice(),
             self.context.encode().as_ref(),
             &self.challenge[..],
             &self.authority_id[..],

--- a/authenticators/solana/src/sol.rs
+++ b/authenticators/solana/src/sol.rs
@@ -26,14 +26,9 @@ pub fn verify_ed25519(pubkey: &SolPubkey, message: &[u8], signature: &[u8; 64]) 
 }
 
 #[cfg(feature = "full-crypto")]
-pub trait Sign<Cx> {
+impl<Cx: Encode> SignedMessage<Cx> {
     /// Sign the message payload with an Ed25519 key pair.
-    fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64];
-}
-
-#[cfg(feature = "full-crypto")]
-impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
-    fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64] {
+    pub fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64] {
         use sp_core::Pair;
         let payload = self.payload();
         pair.sign(&payload).0

--- a/authenticators/solana/src/tests.rs
+++ b/authenticators/solana/src/tests.rs
@@ -1,0 +1,180 @@
+use crate::mock::*;
+use crate::{Sign, SignedMessage, SolPubkey, SolRegistration, SolSignature};
+use frame::{
+    deps::sp_core::{ed25519, Pair},
+    testing_prelude::*,
+    traits::TxBaseImplication,
+};
+use traits_authn::{Challenger, ExtrinsicContext, HashedUserId};
+
+const USER: HashedUserId = *b"phantom\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+parameter_types! {
+    pub SolKey: ed25519::Pair = ed25519::Pair::from_seed(&[3u8; 32]);
+    pub UserAddress: AccountId = Pass::address_for(USER);
+}
+
+fn sol_pubkey_of(pair: &ed25519::Pair) -> SolPubkey {
+    SolPubkey(pair.public().0)
+}
+
+fn make_signature(xtc: &impl ExtrinsicContext) -> (SignedMessage<u64>, SolPubkey, [u8; 64]) {
+    let context = System::block_number();
+    let message = SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: AuthorityId::get(),
+    };
+    let pair = SolKey::get();
+    let pubkey = sol_pubkey_of(&pair);
+    let signature = message.sign(&pair);
+
+    (message, pubkey, signature)
+}
+
+mod registration {
+    use super::*;
+
+    #[test]
+    fn registration_fails_if_attestation_is_invalid() {
+        new_test_ext().execute_with(|| {
+            let (mut message, pubkey, signature) = make_signature(&[]);
+            message.challenge = [0u8; 32];
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    SolRegistration {
+                        pubkey,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_fails_with_wrong_pubkey() {
+        new_test_ext().execute_with(|| {
+            let (message, _pubkey, signature) = make_signature(&UserAddress::get().encode());
+            let wrong = SolPubkey([0xAB; 32]);
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    SolRegistration {
+                        pubkey: wrong,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_works_if_attestation_is_valid() {
+        new_test_ext().execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                SolRegistration {
+                    pubkey,
+                    message,
+                    signature,
+                }
+            ));
+        })
+    }
+}
+
+mod authentication {
+    use super::*;
+
+    fn new_test_ext() -> TestExternalities {
+        let mut t = super::new_test_ext();
+        t.execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                SolRegistration {
+                    pubkey,
+                    message,
+                    signature,
+                }
+            ));
+        });
+        t
+    }
+
+    #[test]
+    fn authentication_fails_if_credentials_are_invalid() {
+        new_test_ext().execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&[]);
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                pubkey.as_ref().clone(),
+                SolSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            assert_noop!(
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
+            );
+        })
+    }
+
+    #[test]
+    fn authentication_works_if_credentials_are_valid() {
+        new_test_ext().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            let (message, pubkey, signature) = make_signature(
+                &TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256),
+            );
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                pubkey.as_ref().clone(),
+                SolSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+        })
+    }
+}

--- a/authenticators/solana/src/tests.rs
+++ b/authenticators/solana/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::mock::*;
-use crate::{Sign, SignedMessage, SolPubkey, SolRegistration, SolSignature};
+use crate::{SignedMessage, SolPubkey, SolRegistration, SolSignature};
 use frame::{
     deps::sp_core::{ed25519, Pair},
     testing_prelude::*,

--- a/authenticators/solana/src/tests.rs
+++ b/authenticators/solana/src/tests.rs
@@ -178,3 +178,42 @@ mod authentication {
         })
     }
 }
+
+mod edge_cases {
+    use super::*;
+
+    #[test]
+    fn verify_fails_with_zero_pubkey() {
+        new_test_ext().execute_with(|| {
+            let pair = SolKey::get();
+            let payload = b"test message";
+            let sig = pair.sign(payload);
+
+            let zero_pubkey = SolPubkey([0u8; 32]);
+            assert!(!crate::sol::verify_ed25519(&zero_pubkey, payload, &sig.0));
+        })
+    }
+
+    #[test]
+    fn verify_fails_with_zero_signature() {
+        new_test_ext().execute_with(|| {
+            let pair = SolKey::get();
+            let pubkey = sol_pubkey_of(&pair);
+            let sig = [0u8; 64];
+            assert!(!crate::sol::verify_ed25519(&pubkey, b"test", &sig));
+        })
+    }
+
+    #[test]
+    fn verify_fails_with_tampered_signature() {
+        new_test_ext().execute_with(|| {
+            let pair = SolKey::get();
+            let pubkey = sol_pubkey_of(&pair);
+            let payload = b"tampered test";
+            let mut sig = pair.sign(payload).0;
+            sig[0] ^= 0x01;
+
+            assert!(!crate::sol::verify_ed25519(&pubkey, payload, &sig));
+        })
+    }
+}

--- a/authenticators/ssh/Cargo.toml
+++ b/authenticators/ssh/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+name = "pass-authenticators-ssh"
+repository.workspace = true
+version = "0.1.0"
+
+[dependencies]
+codec.workspace = true
+log.workspace = true
+scale-info.workspace = true
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+traits-authn.workspace = true
+
+[dev-dependencies]
+frame.workspace = true
+pallet-balances.workspace = true
+pallet-pass.workspace = true
+pallet-scheduler.workspace = true
+
+[features]
+default = ["std", "runtime", "full-crypto"]
+runtime = []
+full-crypto = ["sp-core/full_crypto"]
+std = [
+  "codec/std",
+  "frame/std",
+  "log/std",
+  "pallet-balances/std",
+  "pallet-pass/std",
+  "pallet-scheduler/std",
+  "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "traits-authn/std",
+]
+try-runtime = [
+  "pallet-pass/try-runtime",
+  "pallet-balances/try-runtime",
+  "pallet-scheduler/try-runtime",
+  "frame/try-runtime",
+  "sp-runtime/try-runtime",
+]

--- a/authenticators/ssh/src/lib.rs
+++ b/authenticators/ssh/src/lib.rs
@@ -1,0 +1,93 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+//! # SSH Ed25519 Authenticator for Pallet Pass
+//!
+//! Verifies Ed25519 signatures following the SSH signing format (RFC 8709),
+//! useful for developer workflows where SSH keys are already available.
+//!
+//! The signed data follows the SSH `SSHSIG` wire format:
+//! `MAGIC_PREAMBLE || namespace || reserved || hash_algorithm || H(message)`
+
+use codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+use traits_authn::{AuthorityId, Challenge, DeviceId, HashedUserId};
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+#[cfg(any(test, feature = "runtime"))]
+mod runtime {
+    use super::*;
+    use traits_authn::{prelude::*, util::*};
+    const LOG_TARGET: &str = "pass_authenticators_ssh";
+
+    mod key_registration;
+    mod key_signature;
+
+    type CxOf<Ch> = <Ch as Challenger>::Context;
+    pub type Authenticator<Ch, AuthId> = Auth<Device<Ch, AuthId>, SshRegistration<CxOf<Ch>>>;
+    pub type Device<Ch, A> = Dev<SshPubkey, A, Ch, SshSignature<CxOf<Ch>>>;
+}
+
+#[cfg(any(feature = "runtime", test))]
+pub use runtime::{Authenticator, Device};
+
+mod ssh;
+
+/// A 32-byte Ed25519 public key (SSH key fingerprint maps to this).
+#[derive(
+    Clone,
+    Copy,
+    Encode,
+    Decode,
+    DecodeWithMemTracking,
+    TypeInfo,
+    MaxEncodedLen,
+    PartialEq,
+    Eq,
+    Debug,
+)]
+pub struct SshPubkey(pub [u8; 32]);
+
+impl AsRef<DeviceId> for SshPubkey {
+    fn as_ref(&self) -> &DeviceId {
+        &self.0
+    }
+}
+
+/// A signed message containing the challenge context and authority.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SignedMessage<Cx> {
+    pub context: Cx,
+    pub challenge: Challenge,
+    pub authority_id: AuthorityId,
+}
+
+/// Registration of an SSH Ed25519 public key as a device.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SshRegistration<Cx> {
+    pub pubkey: SshPubkey,
+    pub message: SignedMessage<Cx>,
+    /// 64-byte Ed25519 signature
+    pub signature: [u8; 64],
+}
+
+/// A credential proving the user controls an SSH key.
+#[derive(
+    Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen, PartialEq, Eq, Debug,
+)]
+pub struct SshSignature<Cx> {
+    pub user_id: HashedUserId,
+    pub message: SignedMessage<Cx>,
+    /// 64-byte Ed25519 signature
+    pub signature: [u8; 64],
+}
+
+#[cfg(feature = "full-crypto")]
+pub use ssh::Sign;

--- a/authenticators/ssh/src/lib.rs
+++ b/authenticators/ssh/src/lib.rs
@@ -88,6 +88,3 @@ pub struct SshSignature<Cx> {
     /// 64-byte Ed25519 signature
     pub signature: [u8; 64],
 }
-
-#[cfg(feature = "full-crypto")]
-pub use ssh::Sign;

--- a/authenticators/ssh/src/mock.rs
+++ b/authenticators/ssh/src/mock.rs
@@ -1,0 +1,115 @@
+use frame::{
+    deps::sp_runtime::MultiSignature,
+    testing_prelude::*,
+    traits::{EqualPrivilegeOnly, Verify},
+};
+use traits_authn::{
+    util::AuthorityFromPalletId,
+    {Challenger, ExtrinsicContext},
+};
+
+#[frame_construct_runtime]
+pub mod runtime {
+    #[runtime::runtime]
+    #[runtime::derive(
+        RuntimeCall,
+        RuntimeEvent,
+        RuntimeError,
+        RuntimeOrigin,
+        RuntimeTask,
+        RuntimeHoldReason,
+        RuntimeFreezeReason
+    )]
+    pub struct Test;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+    #[runtime::pallet_index(1)]
+    pub type Scheduler = pallet_scheduler;
+    #[runtime::pallet_index(2)]
+    pub type Pass = pallet_pass;
+
+    #[runtime::pallet_index(10)]
+    pub type Balances = pallet_balances;
+}
+
+pub type Block = MockBlock<Test>;
+
+pub type Signature = MultiSignature;
+pub type AccountPublic = <Signature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+
+pub type Balance = <Test as pallet_balances::Config>::Balance;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+    type AccountStore = System;
+}
+
+parameter_types! {
+    pub MaxWeight: Weight = Weight::MAX;
+}
+
+impl pallet_scheduler::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type MaximumWeight = MaxWeight;
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    type OriginPrivilegeCmp = EqualPrivilegeOnly;
+    type MaxScheduledPerBlock = ConstU32<256>;
+    type WeightInfo = ();
+    type Preimages = ();
+    type BlockNumberProvider = System;
+}
+
+parameter_types! {
+    pub PassPalletId: PalletId = PalletId(*b"pass_ssh");
+    pub RootAccount: AccountId = AccountId::new([0x0; 32]);
+}
+
+pub type AuthorityId = AuthorityFromPalletId<PassPalletId>;
+
+pub struct BlockChallenger;
+impl Challenger for BlockChallenger {
+    type Context = BlockNumberFor<Test>;
+
+    fn generate(ctx: &Self::Context, xtc: &impl ExtrinsicContext) -> traits_authn::Challenge {
+        <Test as frame_system::Config>::Hashing::hash(&((ctx, xtc.as_ref()).encode())).0
+    }
+}
+
+impl pallet_pass::Config for Test {
+    type PalletsOrigin = OriginCaller;
+    type WeightInfo = ();
+    type RegisterOrigin = EnsureRootWithSuccess<Self::AccountId, RootAccount>;
+    type AddressGenerator = ();
+    type Balances = Balances;
+    type Authenticator = crate::Authenticator<BlockChallenger, AuthorityId>;
+    type Scheduler = Scheduler;
+    type BlockNumberProvider = System;
+    type RegistrarConsideration = ();
+    type DeviceConsideration = ();
+    type SessionKeyConsideration = ();
+    type PalletId = PassPalletId;
+    type MaxDevicesPerAccount = ConstU32<1>;
+    type MaxSessionsPerAccount = ConstU32<1>;
+    type MaxSessionDuration = ConstU64<10>;
+}
+
+pub fn new_test_ext() -> TestExternalities {
+    let mut t = TestExternalities::default();
+    t.execute_with(|| {
+        System::set_block_number(1);
+    });
+    t
+}

--- a/authenticators/ssh/src/runtime/key_registration.rs
+++ b/authenticators/ssh/src/runtime/key_registration.rs
@@ -1,0 +1,32 @@
+use super::*;
+use crate::ssh::verify_ssh_ed25519;
+
+impl<Ch: Challenger, AuthId> From<SshRegistration<CxOf<Ch>>> for Device<Ch, AuthId> {
+    fn from(reg: SshRegistration<CxOf<Ch>>) -> Self {
+        Self::new(reg.pubkey)
+    }
+}
+
+impl<Cx: Parameter + Encode + 'static> DeviceChallengeResponse<Cx> for SshRegistration<Cx> {
+    fn is_valid(&self) -> bool {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying SSH Ed25519 registration of {:?}",
+            self.pubkey,
+        );
+        let signed_data = self.message.ssh_signed_data();
+        verify_ssh_ed25519(&self.pubkey, &signed_data, &self.signature)
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn device_id(&self) -> &DeviceId {
+        self.pubkey.as_ref()
+    }
+}

--- a/authenticators/ssh/src/runtime/key_signature.rs
+++ b/authenticators/ssh/src/runtime/key_signature.rs
@@ -1,0 +1,33 @@
+use super::*;
+use crate::ssh::verify_ssh_ed25519;
+use traits_authn::UserChallengeResponse;
+
+impl<Cx: Parameter + Encode + 'static> UserChallengeResponse<Cx> for SshSignature<Cx> {
+    fn is_valid(&self) -> bool {
+        true
+    }
+
+    fn used_challenge(&self) -> (Cx, Challenge) {
+        (self.message.context.clone(), self.message.challenge)
+    }
+
+    fn authority(&self) -> AuthorityId {
+        self.message.authority_id
+    }
+
+    fn user_id(&self) -> HashedUserId {
+        self.user_id
+    }
+}
+
+impl<Cx: Encode> VerifyCredential<SshSignature<Cx>> for SshPubkey {
+    fn verify(&mut self, credential: &SshSignature<Cx>) -> Option<()> {
+        log::debug!(
+            target: LOG_TARGET,
+            "Verifying SSH Ed25519 signature for {:?}",
+            self,
+        );
+        let signed_data = credential.message.ssh_signed_data();
+        verify_ssh_ed25519(self, &signed_data, &credential.signature).then_some(())
+    }
+}

--- a/authenticators/ssh/src/ssh.rs
+++ b/authenticators/ssh/src/ssh.rs
@@ -11,9 +11,11 @@ const NAMESPACE: &[u8] = b"pallet-pass";
 const HASH_ALGO: &[u8] = b"sha256";
 
 impl<Cx: Encode> SignedMessage<Cx> {
-    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    /// The domain-separated payload bytes.
+    /// Prefixed with `b"SSH"` to prevent cross-authenticator signature replay.
     pub fn payload(&self) -> Vec<u8> {
         [
+            b"SSH".as_slice(),
             self.context.encode().as_ref(),
             &self.challenge[..],
             &self.authority_id[..],

--- a/authenticators/ssh/src/ssh.rs
+++ b/authenticators/ssh/src/ssh.rs
@@ -63,14 +63,9 @@ pub fn verify_ssh_ed25519(pubkey: &SshPubkey, signed_data: &[u8], signature: &[u
 }
 
 #[cfg(feature = "full-crypto")]
-pub trait Sign<Cx> {
+impl<Cx: Encode> SignedMessage<Cx> {
     /// Sign the SSHSIG-formatted data with an Ed25519 key pair.
-    fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64];
-}
-
-#[cfg(feature = "full-crypto")]
-impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
-    fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64] {
+    pub fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64] {
         use sp_core::Pair;
         let data = self.ssh_signed_data();
         pair.sign(&data).0

--- a/authenticators/ssh/src/ssh.rs
+++ b/authenticators/ssh/src/ssh.rs
@@ -1,0 +1,76 @@
+use super::*;
+
+extern crate alloc;
+use alloc::vec::Vec;
+
+/// SSH signature magic preamble (RFC 8709 / SSHSIG format).
+const MAGIC_PREAMBLE: &[u8] = b"SSHSIG";
+/// Namespace for pallet-pass authentication.
+const NAMESPACE: &[u8] = b"pallet-pass";
+/// Hash algorithm identifier.
+const HASH_ALGO: &[u8] = b"sha256";
+
+impl<Cx: Encode> SignedMessage<Cx> {
+    /// The raw payload bytes (SCALE-encoded context || challenge || authority_id).
+    pub fn payload(&self) -> Vec<u8> {
+        [
+            self.context.encode().as_ref(),
+            &self.challenge[..],
+            &self.authority_id[..],
+        ]
+        .concat()
+    }
+
+    /// Build the SSHSIG-style signed data.
+    ///
+    /// Format:
+    /// ```text
+    /// MAGIC_PREAMBLE (6 bytes)
+    /// namespace_len (4 bytes BE) || namespace
+    /// reserved_len (4 bytes BE, = 0)
+    /// hash_algo_len (4 bytes BE) || hash_algo
+    /// hash_len (4 bytes BE) || SHA256(payload)
+    /// ```
+    pub fn ssh_signed_data(&self) -> Vec<u8> {
+        let payload = self.payload();
+        let hash = sp_io::hashing::sha2_256(&payload);
+
+        let mut data = Vec::new();
+        data.extend_from_slice(MAGIC_PREAMBLE);
+        // namespace (string)
+        data.extend_from_slice(&(NAMESPACE.len() as u32).to_be_bytes());
+        data.extend_from_slice(NAMESPACE);
+        // reserved (empty string)
+        data.extend_from_slice(&0u32.to_be_bytes());
+        // hash algorithm (string)
+        data.extend_from_slice(&(HASH_ALGO.len() as u32).to_be_bytes());
+        data.extend_from_slice(HASH_ALGO);
+        // hash (string)
+        data.extend_from_slice(&(hash.len() as u32).to_be_bytes());
+        data.extend_from_slice(&hash);
+
+        data
+    }
+}
+
+/// Verify an Ed25519 signature against an SSH public key using the SSHSIG format.
+pub fn verify_ssh_ed25519(pubkey: &SshPubkey, signed_data: &[u8], signature: &[u8; 64]) -> bool {
+    let ed_pub = sp_core::ed25519::Public::from_raw(pubkey.0);
+    let ed_sig = sp_core::ed25519::Signature::from_raw(*signature);
+    sp_io::crypto::ed25519_verify(&ed_sig, signed_data, &ed_pub)
+}
+
+#[cfg(feature = "full-crypto")]
+pub trait Sign<Cx> {
+    /// Sign the SSHSIG-formatted data with an Ed25519 key pair.
+    fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64];
+}
+
+#[cfg(feature = "full-crypto")]
+impl<Cx: Encode> Sign<Cx> for SignedMessage<Cx> {
+    fn sign(&self, pair: &sp_core::ed25519::Pair) -> [u8; 64] {
+        use sp_core::Pair;
+        let data = self.ssh_signed_data();
+        pair.sign(&data).0
+    }
+}

--- a/authenticators/ssh/src/tests.rs
+++ b/authenticators/ssh/src/tests.rs
@@ -202,3 +202,42 @@ mod sshsig_format {
         })
     }
 }
+
+mod edge_cases {
+    use super::*;
+
+    #[test]
+    fn verify_fails_with_zero_pubkey() {
+        new_test_ext().execute_with(|| {
+            let pair = SshKey::get();
+            let data = b"test";
+            let sig = pair.sign(data);
+
+            let zero_pubkey = SshPubkey([0u8; 32]);
+            assert!(!crate::ssh::verify_ssh_ed25519(&zero_pubkey, data, &sig.0));
+        })
+    }
+
+    #[test]
+    fn verify_fails_with_zero_signature() {
+        new_test_ext().execute_with(|| {
+            let pair = SshKey::get();
+            let pubkey = ssh_pubkey_of(&pair);
+            let sig = [0u8; 64];
+            assert!(!crate::ssh::verify_ssh_ed25519(&pubkey, b"test", &sig));
+        })
+    }
+
+    #[test]
+    fn verify_fails_with_tampered_signature() {
+        new_test_ext().execute_with(|| {
+            let pair = SshKey::get();
+            let pubkey = ssh_pubkey_of(&pair);
+            let data = b"tampered";
+            let mut sig = pair.sign(data.as_slice()).0;
+            sig[0] ^= 0x01;
+
+            assert!(!crate::ssh::verify_ssh_ed25519(&pubkey, data, &sig));
+        })
+    }
+}

--- a/authenticators/ssh/src/tests.rs
+++ b/authenticators/ssh/src/tests.rs
@@ -1,5 +1,5 @@
 use crate::mock::*;
-use crate::{Sign, SignedMessage, SshPubkey, SshRegistration, SshSignature};
+use crate::{SignedMessage, SshPubkey, SshRegistration, SshSignature};
 use frame::{
     deps::sp_core::{ed25519, Pair},
     testing_prelude::*,

--- a/authenticators/ssh/src/tests.rs
+++ b/authenticators/ssh/src/tests.rs
@@ -1,0 +1,204 @@
+use crate::mock::*;
+use crate::{Sign, SignedMessage, SshPubkey, SshRegistration, SshSignature};
+use frame::{
+    deps::sp_core::{ed25519, Pair},
+    testing_prelude::*,
+    traits::TxBaseImplication,
+};
+use traits_authn::{Challenger, ExtrinsicContext, HashedUserId};
+
+const USER: HashedUserId = *b"dev_user\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+parameter_types! {
+    pub SshKey: ed25519::Pair = ed25519::Pair::from_seed(&[5u8; 32]);
+    pub UserAddress: AccountId = Pass::address_for(USER);
+}
+
+fn ssh_pubkey_of(pair: &ed25519::Pair) -> SshPubkey {
+    SshPubkey(pair.public().0)
+}
+
+fn make_signature(xtc: &impl ExtrinsicContext) -> (SignedMessage<u64>, SshPubkey, [u8; 64]) {
+    let context = System::block_number();
+    let message = SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: AuthorityId::get(),
+    };
+    let pair = SshKey::get();
+    let pubkey = ssh_pubkey_of(&pair);
+    let signature = message.sign(&pair);
+
+    (message, pubkey, signature)
+}
+
+mod registration {
+    use super::*;
+
+    #[test]
+    fn registration_fails_if_attestation_is_invalid() {
+        new_test_ext().execute_with(|| {
+            let (mut message, pubkey, signature) = make_signature(&[]);
+            message.challenge = [0u8; 32];
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    SshRegistration {
+                        pubkey,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_fails_with_wrong_pubkey() {
+        new_test_ext().execute_with(|| {
+            let (message, _pubkey, signature) = make_signature(&UserAddress::get().encode());
+            let wrong = SshPubkey([0xAB; 32]);
+
+            assert_noop!(
+                Pass::register(
+                    RuntimeOrigin::root(),
+                    USER,
+                    SshRegistration {
+                        pubkey: wrong,
+                        message,
+                        signature,
+                    }
+                ),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+
+    #[test]
+    fn registration_works_if_attestation_is_valid() {
+        new_test_ext().execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                SshRegistration {
+                    pubkey,
+                    message,
+                    signature,
+                }
+            ));
+        })
+    }
+}
+
+mod authentication {
+    use super::*;
+
+    fn new_test_ext() -> TestExternalities {
+        let mut t = super::new_test_ext();
+        t.execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&UserAddress::get().encode());
+
+            assert_ok!(Pass::register(
+                RuntimeOrigin::root(),
+                USER,
+                SshRegistration {
+                    pubkey,
+                    message,
+                    signature,
+                }
+            ));
+        });
+        t
+    }
+
+    #[test]
+    fn authentication_fails_if_credentials_are_invalid() {
+        new_test_ext().execute_with(|| {
+            let (message, pubkey, signature) = make_signature(&[]);
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                pubkey.as_ref().clone(),
+                SshSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            assert_noop!(
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
+            );
+        })
+    }
+
+    #[test]
+    fn authentication_works_if_credentials_are_valid() {
+        new_test_ext().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+
+            let (message, pubkey, signature) = make_signature(
+                &TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256),
+            );
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                pubkey.as_ref().clone(),
+                SshSignature {
+                    user_id: USER,
+                    message,
+                    signature,
+                },
+            );
+
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+        })
+    }
+}
+
+mod sshsig_format {
+    use super::*;
+
+    #[test]
+    fn signed_data_contains_magic_preamble() {
+        new_test_ext().execute_with(|| {
+            let (message, _, _) = make_signature(&[]);
+            let data = message.ssh_signed_data();
+            assert_eq!(&data[..6], b"SSHSIG");
+        })
+    }
+
+    #[test]
+    fn signed_data_contains_namespace() {
+        new_test_ext().execute_with(|| {
+            let (message, _, _) = make_signature(&[]);
+            let data = message.ssh_signed_data();
+            // After preamble (6), namespace length (4 bytes BE), then namespace
+            let ns_len = u32::from_be_bytes(data[6..10].try_into().unwrap()) as usize;
+            assert_eq!(&data[10..10 + ns_len], b"pallet-pass");
+        })
+    }
+}

--- a/integration-tests/Cargo.toml
+++ b/integration-tests/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "pass-authenticators-integration-tests"
+edition.workspace = true
+version = "0.1.0"
+publish = false
+
+[dependencies]
+codec.workspace = true
+ripemd.workspace = true
+frame.workspace = true
+k256.workspace = true
+log.workspace = true
+pallet-balances.workspace = true
+pallet-pass.workspace = true
+pallet-scheduler.workspace = true
+pass-ethereum = { path = "../authenticators/ethereum", package = "pass-authenticators-ethereum" }
+pass-bitcoin = { path = "../authenticators/bitcoin", package = "pass-authenticators-bitcoin" }
+pass-solana = { path = "../authenticators/solana", package = "pass-authenticators-solana" }
+pass-nostr = { path = "../authenticators/nostr", package = "pass-authenticators-nostr" }
+pass-ssh = { path = "../authenticators/ssh", package = "pass-authenticators-ssh" }
+scale-info.workspace = true
+sp-core.workspace = true
+sp-io.workspace = true
+sp-runtime.workspace = true
+traits-authn.workspace = true
+
+[features]
+default = ["std"]
+std = [
+  "codec/std",
+  "frame/std",
+  "k256/std",
+  "log/std",
+  "pallet-balances/std",
+  "pallet-pass/std",
+  "pallet-scheduler/std",
+  "pass-ethereum/std",
+  "pass-bitcoin/std",
+  "pass-solana/std",
+  "pass-nostr/std",
+  "pass-ssh/std",
+  "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
+  "sp-runtime/std",
+  "traits-authn/std",
+]

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -1,0 +1,9 @@
+#![cfg(test)]
+
+//! Integration tests for pass-authenticators with a composite multi-authenticator runtime.
+//!
+//! Tests cross-authenticator security boundaries, DeviceId isolation, session key
+//! permission escalation, and challenge replay scenarios.
+
+mod mock;
+mod tests;

--- a/integration-tests/src/mock.rs
+++ b/integration-tests/src/mock.rs
@@ -1,0 +1,136 @@
+use frame::{
+    deps::sp_runtime::MultiSignature,
+    testing_prelude::*,
+    traits::{EqualPrivilegeOnly, Verify},
+};
+use traits_authn::{
+    composite_authenticator,
+    util::AuthorityFromPalletId,
+    {Challenger, ExtrinsicContext},
+};
+
+// ---------- Concrete authenticator type aliases ----------
+
+pub type PassAuthority = AuthorityFromPalletId<PassPalletId>;
+
+pub struct BlockChallenger;
+impl Challenger for BlockChallenger {
+    type Context = BlockNumberFor<Test>;
+
+    fn generate(ctx: &Self::Context, xtc: &impl ExtrinsicContext) -> traits_authn::Challenge {
+        <Test as frame_system::Config>::Hashing::hash(&((ctx, xtc.as_ref()).encode())).0
+    }
+}
+
+pub type Eth = pass_ethereum::Authenticator<BlockChallenger, PassAuthority>;
+pub type Btc = pass_bitcoin::Authenticator<BlockChallenger, PassAuthority>;
+pub type Sol = pass_solana::Authenticator<BlockChallenger, PassAuthority>;
+pub type Nostr = pass_nostr::Authenticator<BlockChallenger, PassAuthority>;
+pub type Ssh = pass_ssh::Authenticator<BlockChallenger, PassAuthority>;
+
+composite_authenticator!(
+    pub Pass<PassAuthority> {
+        Eth,
+        Btc,
+        Sol,
+        Nostr,
+        Ssh,
+    }
+);
+
+// ---------- Runtime ----------
+
+#[frame_construct_runtime]
+pub mod runtime {
+    #[runtime::runtime]
+    #[runtime::derive(
+        RuntimeCall,
+        RuntimeEvent,
+        RuntimeError,
+        RuntimeOrigin,
+        RuntimeTask,
+        RuntimeHoldReason,
+        RuntimeFreezeReason
+    )]
+    pub struct Test;
+
+    #[runtime::pallet_index(0)]
+    pub type System = frame_system;
+    #[runtime::pallet_index(1)]
+    pub type Scheduler = pallet_scheduler;
+    #[runtime::pallet_index(2)]
+    pub type PassPallet = pallet_pass;
+
+    #[runtime::pallet_index(10)]
+    pub type Balances = pallet_balances;
+}
+
+pub type Block = MockBlock<Test>;
+
+pub type Signature = MultiSignature;
+pub type AccountPublic = <Signature as Verify>::Signer;
+pub type AccountId = <AccountPublic as IdentifyAccount>::AccountId;
+
+pub type Balance = <Test as pallet_balances::Config>::Balance;
+
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
+    type Block = Block;
+    type AccountId = AccountId;
+    type Lookup = IdentityLookup<Self::AccountId>;
+    type AccountData = pallet_balances::AccountData<Balance>;
+}
+
+#[derive_impl(pallet_balances::config_preludes::TestDefaultConfig)]
+impl pallet_balances::Config for Test {
+    type AccountStore = System;
+}
+
+parameter_types! {
+    pub MaxWeight: Weight = Weight::MAX;
+}
+
+impl pallet_scheduler::Config for Test {
+    type RuntimeEvent = RuntimeEvent;
+    type RuntimeOrigin = RuntimeOrigin;
+    type PalletsOrigin = OriginCaller;
+    type RuntimeCall = RuntimeCall;
+    type MaximumWeight = MaxWeight;
+    type ScheduleOrigin = EnsureRoot<AccountId>;
+    type OriginPrivilegeCmp = EqualPrivilegeOnly;
+    type MaxScheduledPerBlock = ConstU32<256>;
+    type WeightInfo = ();
+    type Preimages = ();
+    type BlockNumberProvider = System;
+}
+
+parameter_types! {
+    pub PassPalletId: PalletId = PalletId(*b"pass_int");
+    pub RootAccount: AccountId = AccountId::new([0x0; 32]);
+}
+
+impl pallet_pass::Config for Test {
+    type PalletsOrigin = OriginCaller;
+    type WeightInfo = ();
+    type RegisterOrigin = EnsureRootWithSuccess<Self::AccountId, RootAccount>;
+    type AddressGenerator = ();
+    type Balances = Balances;
+    type Authenticator = PassAuthenticator;
+    type Scheduler = Scheduler;
+    type BlockNumberProvider = System;
+    type RegistrarConsideration = ();
+    type DeviceConsideration = ();
+    type SessionKeyConsideration = ();
+    type PalletId = PassPalletId;
+    type MaxDevicesPerAccount = ConstU32<5>;
+    type MaxSessionsPerAccount = ConstU32<3>;
+    type MaxSessionDuration = ConstU64<10>;
+}
+
+pub fn new_test_ext() -> TestExternalities {
+    let mut t = TestExternalities::default();
+    t.execute_with(|| {
+        System::set_block_number(1);
+    });
+    t
+}

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -64,7 +64,6 @@ fn make_eth_registration(
     let address = eth_address_of(&pair);
     let signature =
         <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(&message, &pair);
-
     let attestation = PassDeviceAttestation::Eth(pass_ethereum::EthRegistration {
         address,
         message,
@@ -86,7 +85,6 @@ fn make_sol_registration(
     let pubkey = pass_solana::SolPubkey(pair.public().0);
     let signature =
         <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(&message, &pair);
-
     let attestation = PassDeviceAttestation::Sol(pass_solana::SolRegistration {
         pubkey,
         message,
@@ -108,7 +106,6 @@ fn make_btc_registration(
     let pubkey_hash = btc_pubkey_hash_of(&pair);
     let signature =
         <pass_bitcoin::SignedMessage<u64> as pass_bitcoin::Sign<u64>>::sign(&message, &pair);
-
     let attestation = PassDeviceAttestation::Btc(pass_bitcoin::BtcRegistration {
         pubkey_hash,
         message,
@@ -129,13 +126,31 @@ fn make_ssh_registration(
     let pair = SshKey::get();
     let pubkey = pass_ssh::SshPubkey(pair.public().0);
     let signature = <pass_ssh::SignedMessage<u64> as pass_ssh::Sign<u64>>::sign(&message, &pair);
-
     let attestation = PassDeviceAttestation::Ssh(pass_ssh::SshRegistration {
         pubkey,
         message,
         signature,
     });
     (pubkey, attestation)
+}
+
+fn make_eth_credential(xtc: &impl ExtrinsicContext) -> (pass_ethereum::EthAddress, PassCredential) {
+    let context = System::block_number();
+    let message = pass_ethereum::SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: PassAuthority::get(),
+    };
+    let pair = EthKey::get();
+    let address = eth_address_of(&pair);
+    let signature =
+        <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(&message, &pair);
+    let credential = PassCredential::Eth(pass_ethereum::EthSignature {
+        user_id: ETH_USER,
+        message,
+        signature,
+    });
+    (address, credential)
 }
 
 // ---------- Cross-authenticator replay tests ----------
@@ -146,19 +161,15 @@ mod cross_authenticator {
     fn setup() -> TestExternalities {
         let mut t = new_test_ext();
         t.execute_with(|| {
-            // Register ETH device
             let (_, att) = make_eth_registration(&EthUserAddress::get().encode());
             assert_ok!(PassPallet::register(RuntimeOrigin::root(), ETH_USER, att));
 
-            // Register SOL device
             let (_, att) = make_sol_registration(&SolUserAddress::get().encode());
             assert_ok!(PassPallet::register(RuntimeOrigin::root(), SOL_USER, att));
 
-            // Register BTC device
             let (_, att) = make_btc_registration(&BtcUserAddress::get().encode());
             assert_ok!(PassPallet::register(RuntimeOrigin::root(), BTC_USER, att));
 
-            // Register SSH device
             let (_, att) = make_ssh_registration(&SshUserAddress::get().encode());
             assert_ok!(PassPallet::register(RuntimeOrigin::root(), SSH_USER, att));
         });
@@ -173,7 +184,6 @@ mod cross_authenticator {
             let xtc =
                 TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
 
-            // Create a valid ETH signature
             let context = System::block_number();
             let eth_msg = pass_ethereum::SignedMessage {
                 context,
@@ -185,12 +195,12 @@ mod cross_authenticator {
                 &EthKey::get(),
             );
 
-            // Wrap in ETH credential but use SOL account's device_id
+            // Use SOL device_id with ETH credential → must fail
             let sol_pubkey = pass_solana::SolPubkey(SolKey::get().public().0);
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
-                sol_pubkey.0, // SOL's device_id
+                sol_pubkey.0,
                 PassCredential::Eth(pass_ethereum::EthSignature {
-                    user_id: SOL_USER, // Try to auth as SOL user
+                    user_id: SOL_USER,
                     message: eth_msg,
                     signature: eth_sig,
                 }),
@@ -219,7 +229,6 @@ mod cross_authenticator {
             let xtc =
                 TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
 
-            // Create a valid SOL signature
             let context = System::block_number();
             let sol_msg = pass_solana::SignedMessage {
                 context,
@@ -231,12 +240,11 @@ mod cross_authenticator {
                 &SolKey::get(),
             );
 
-            // Wrap in SOL credential but use ETH account's device_id
             let eth_addr = eth_address_of(&EthKey::get());
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
-                *eth_addr.as_ref(), // ETH's device_id
+                *eth_addr.as_ref(),
                 PassCredential::Sol(pass_solana::SolSignature {
-                    user_id: ETH_USER, // Try to auth as ETH user
+                    user_id: ETH_USER,
                     message: sol_msg,
                     signature: sol_sig,
                 }),
@@ -276,7 +284,6 @@ mod cross_authenticator {
                 &BtcKey::get(),
             );
 
-            // Use SSH device_id with BTC credential
             let ssh_pubkey = pass_ssh::SshPubkey(SshKey::get().public().0);
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
                 ssh_pubkey.0,
@@ -310,27 +317,8 @@ mod cross_authenticator {
             let xtc =
                 TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
 
-            // Valid ETH auth
-            let context = System::block_number();
-            let eth_msg = pass_ethereum::SignedMessage {
-                context,
-                challenge: BlockChallenger::generate(&context, &xtc),
-                authority_id: PassAuthority::get(),
-            };
-            let eth_sig = <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(
-                &eth_msg,
-                &EthKey::get(),
-            );
-            let eth_addr = eth_address_of(&EthKey::get());
-
-            let ext = pallet_pass::PassAuthenticate::<Test>::from(
-                *eth_addr.as_ref(),
-                PassCredential::Eth(pass_ethereum::EthSignature {
-                    user_id: ETH_USER,
-                    message: eth_msg,
-                    signature: eth_sig,
-                }),
-            );
+            let (address, credential) = make_eth_credential(&xtc);
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(*address.as_ref(), credential);
 
             assert_ok!(ext
                 .validate_only(
@@ -354,7 +342,7 @@ mod cross_authenticator {
                 TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
             let context = System::block_number();
 
-            // SOL auth
+            // SOL
             let sol_msg = pass_solana::SignedMessage {
                 context,
                 challenge: BlockChallenger::generate(&context, &xtc),
@@ -364,10 +352,8 @@ mod cross_authenticator {
                 &sol_msg,
                 &SolKey::get(),
             );
-            let sol_pubkey = pass_solana::SolPubkey(SolKey::get().public().0);
-
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
-                sol_pubkey.0,
+                SolKey::get().public().0,
                 PassCredential::Sol(pass_solana::SolSignature {
                     user_id: SOL_USER,
                     message: sol_msg,
@@ -385,7 +371,7 @@ mod cross_authenticator {
                 )
                 .map(|_| ()));
 
-            // SSH auth
+            // SSH
             let ssh_msg = pass_ssh::SignedMessage {
                 context,
                 challenge: BlockChallenger::generate(&context, &xtc),
@@ -395,10 +381,8 @@ mod cross_authenticator {
                 &ssh_msg,
                 &SshKey::get(),
             );
-            let ssh_pubkey = pass_ssh::SshPubkey(SshKey::get().public().0);
-
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
-                ssh_pubkey.0,
+                SshKey::get().public().0,
                 PassCredential::Ssh(pass_ssh::SshSignature {
                     user_id: SSH_USER,
                     message: ssh_msg,
@@ -419,88 +403,16 @@ mod cross_authenticator {
     }
 }
 
-// ---------- Session key security ----------
-
-mod session_keys {
-    use super::*;
-
-    fn setup_with_eth() -> TestExternalities {
-        let mut t = new_test_ext();
-        t.execute_with(|| {
-            let (_, att) = make_eth_registration(&EthUserAddress::get().encode());
-            assert_ok!(PassPallet::register(RuntimeOrigin::root(), ETH_USER, att));
-        });
-        t
-    }
-
-    #[test]
-    fn session_key_cannot_register_new_account() {
-        setup_with_eth().execute_with(|| {
-            let extrinsic_version: u8 = 0;
-            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
-            let xtc =
-                TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
-
-            // Create a valid session key
-            let context = System::block_number();
-            let eth_msg = pass_ethereum::SignedMessage {
-                context,
-                challenge: BlockChallenger::generate(&context, &xtc),
-                authority_id: PassAuthority::get(),
-            };
-            let eth_sig = <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(
-                &eth_msg,
-                &EthKey::get(),
-            );
-            let eth_addr = eth_address_of(&EthKey::get());
-
-            let ext = pallet_pass::PassAuthenticate::<Test>::from(
-                *eth_addr.as_ref(),
-                PassCredential::Eth(pass_ethereum::EthSignature {
-                    user_id: ETH_USER,
-                    message: eth_msg,
-                    signature: eth_sig,
-                }),
-            );
-
-            // First verify the auth works
-            assert_ok!(ext
-                .validate_only(
-                    None.into(),
-                    &call,
-                    &call.get_dispatch_info(),
-                    call.encoded_size(),
-                    TransactionSource::External,
-                    0
-                )
-                .map(|_| ()));
-
-            // Now add a session key for this account
-            let session_key_pair = ed25519::Pair::from_seed(&[99u8; 32]);
-            let session_key: AccountId = session_key_pair.public().into();
-
-            // Session keys are ephemeral — they can authenticate but should not
-            // be usable to escalate privileges (e.g., register new accounts).
-            // The session key itself is NOT a registered pass account.
-            // Verify that no pass account maps to this session key's address.
-            let session_addr =
-                PassPallet::address_for(*b"session_test\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
-            assert_ne!(session_key, session_addr);
-        })
-    }
-}
-
-// ---------- Device isolation tests ----------
+// ---------- DeviceId collision ----------
 
 mod device_isolation {
     use super::*;
 
     #[test]
-    fn same_ed25519_key_registered_as_sol_and_ssh_are_separate_accounts() {
+    fn duplicate_device_id_across_accounts_is_rejected() {
         new_test_ext().execute_with(|| {
-            // Use the SAME ed25519 key for both SOL and SSH registrations
-            // Due to domain separators, the signatures will be different
-            // But the DeviceId (raw 32-byte pubkey) is identical
+            // Use the SAME ed25519 key for both SOL and SSH.
+            // DeviceId is the raw 32-byte pubkey — identical for both.
             let shared_key = ed25519::Pair::from_seed(&[20u8; 32]);
             let pubkey_bytes = shared_key.public().0;
 
@@ -510,7 +422,7 @@ mod device_isolation {
             let sol_addr = PassPallet::address_for(sol_user);
             let ssh_addr = PassPallet::address_for(ssh_user);
 
-            // Register as SOL
+            // Register SOL device
             let context = System::block_number();
             let sol_msg = pass_solana::SignedMessage {
                 context,
@@ -521,19 +433,18 @@ mod device_isolation {
                 &sol_msg,
                 &shared_key,
             );
-            let sol_att = PassDeviceAttestation::Sol(pass_solana::SolRegistration {
-                pubkey: pass_solana::SolPubkey(pubkey_bytes),
-                message: sol_msg,
-                signature: sol_sig,
-            });
             assert_ok!(PassPallet::register(
                 RuntimeOrigin::root(),
                 sol_user,
-                sol_att
+                PassDeviceAttestation::Sol(pass_solana::SolRegistration {
+                    pubkey: pass_solana::SolPubkey(pubkey_bytes),
+                    message: sol_msg,
+                    signature: sol_sig,
+                })
             ));
 
-            // Try to register the SAME DeviceId as SSH for a different user
-            // pallet-pass should reject because the device_id is already taken
+            // Attempt to register SAME DeviceId as SSH for different user
+            // pallet-pass enforces DeviceId uniqueness via DeviceIds storage
             let ssh_msg = pass_ssh::SignedMessage {
                 context,
                 challenge: BlockChallenger::generate(&context, &ssh_addr.encode()),
@@ -541,62 +452,19 @@ mod device_isolation {
             };
             let ssh_sig =
                 <pass_ssh::SignedMessage<u64> as pass_ssh::Sign<u64>>::sign(&ssh_msg, &shared_key);
-            let ssh_att = PassDeviceAttestation::Ssh(pass_ssh::SshRegistration {
-                pubkey: pass_ssh::SshPubkey(pubkey_bytes),
-                message: ssh_msg,
-                signature: ssh_sig,
-            });
 
-            // This should fail — same device_id cannot be registered to two accounts
-            // (assuming pallet-pass enforces this)
-            let result = PassPallet::register(RuntimeOrigin::root(), ssh_user, ssh_att);
-
-            // If pallet-pass allows it, that's a finding worth documenting
-            if result.is_ok() {
-                // Both registrations succeeded — verify they're on SEPARATE accounts
-                // This means the same physical key controls two accounts
-                // The SOL credential should NOT work for the SSH account
-                let extrinsic_version: u8 = 0;
-                let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
-                let xtc =
-                    TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
-
-                let sol_auth_msg = pass_solana::SignedMessage {
-                    context,
-                    challenge: BlockChallenger::generate(&context, &xtc),
-                    authority_id: PassAuthority::get(),
-                };
-                let sol_auth_sig =
-                    <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(
-                        &sol_auth_msg,
-                        &shared_key,
-                    );
-
-                // Try SOL credential claiming to be SSH user
-                let ext = pallet_pass::PassAuthenticate::<Test>::from(
-                    pubkey_bytes,
-                    PassCredential::Sol(pass_solana::SolSignature {
-                        user_id: ssh_user, // wrong user
-                        message: sol_auth_msg,
-                        signature: sol_auth_sig,
-                    }),
-                );
-
-                // This MUST fail — composite dispatch (Device::Sol, Cred::Sol) would match
-                // on variant but the device stored is SSH variant for this account
-                assert_noop!(
-                    ext.validate_only(
-                        None.into(),
-                        &call,
-                        &call.get_dispatch_info(),
-                        call.encoded_size(),
-                        TransactionSource::External,
-                        0
-                    )
-                    .map(|_| ()),
-                    InvalidTransaction::BadSigner
-                );
-            }
+            assert_noop!(
+                PassPallet::register(
+                    RuntimeOrigin::root(),
+                    ssh_user,
+                    PassDeviceAttestation::Ssh(pass_ssh::SshRegistration {
+                        pubkey: pass_ssh::SshPubkey(pubkey_bytes),
+                        message: ssh_msg,
+                        signature: ssh_sig,
+                    })
+                ),
+                pallet_pass::Error::<Test>::DeviceAlreadyExists
+            );
         })
     }
 }
@@ -612,7 +480,6 @@ mod authority {
             let pair = EthKey::get();
             let address = eth_address_of(&pair);
 
-            // Use a WRONG authority_id
             let context = System::block_number();
             let bad_authority = [0xFFu8; 32];
             let message = pass_ethereum::SignedMessage {
@@ -624,16 +491,160 @@ mod authority {
                 &message, &pair,
             );
 
-            let attestation = PassDeviceAttestation::Eth(pass_ethereum::EthRegistration {
-                address,
-                message,
-                signature,
-            });
-
             assert_noop!(
-                PassPallet::register(RuntimeOrigin::root(), ETH_USER, attestation),
+                PassPallet::register(
+                    RuntimeOrigin::root(),
+                    ETH_USER,
+                    PassDeviceAttestation::Eth(pass_ethereum::EthRegistration {
+                        address,
+                        message,
+                        signature,
+                    })
+                ),
                 pallet_pass::Error::<Test>::DeviceAttestationInvalid,
             );
+        })
+    }
+}
+
+// ---------- Payload domain separation ----------
+
+mod domain_separation {
+    use super::*;
+
+    #[test]
+    fn different_authenticators_produce_different_payloads_for_same_inputs() {
+        new_test_ext().execute_with(|| {
+            let context: u64 = 1;
+            let challenge = [42u8; 32];
+            let authority = [1u8; 32];
+
+            let eth_msg = pass_ethereum::SignedMessage {
+                context,
+                challenge,
+                authority_id: authority,
+            };
+            let sol_msg = pass_solana::SignedMessage {
+                context,
+                challenge,
+                authority_id: authority,
+            };
+            let ssh_msg = pass_ssh::SignedMessage {
+                context,
+                challenge,
+                authority_id: authority,
+            };
+            let btc_msg = pass_bitcoin::SignedMessage {
+                context,
+                challenge,
+                authority_id: authority,
+            };
+            let nostr_msg = pass_nostr::SignedMessage {
+                context,
+                challenge,
+                authority_id: authority,
+            };
+
+            let eth_payload = eth_msg.payload();
+            let sol_payload = sol_msg.payload();
+            let ssh_payload = ssh_msg.payload();
+            let btc_payload = btc_msg.payload();
+            let nostr_payload = nostr_msg.payload();
+
+            // All payloads must be distinct due to domain separators
+            let payloads = [
+                &eth_payload,
+                &sol_payload,
+                &ssh_payload,
+                &btc_payload,
+                &nostr_payload,
+            ];
+            for i in 0..payloads.len() {
+                for j in (i + 1)..payloads.len() {
+                    assert_ne!(
+                        payloads[i], payloads[j],
+                        "Payload collision between authenticators {} and {}",
+                        i, j
+                    );
+                }
+            }
+        })
+    }
+
+    #[test]
+    fn domain_prefixes_are_correct() {
+        new_test_ext().execute_with(|| {
+            let msg = pass_ethereum::SignedMessage {
+                context: 1u64,
+                challenge: [0u8; 32],
+                authority_id: [0u8; 32],
+            };
+            assert!(msg.payload().starts_with(b"ETH"));
+
+            let msg = pass_bitcoin::SignedMessage {
+                context: 1u64,
+                challenge: [0u8; 32],
+                authority_id: [0u8; 32],
+            };
+            assert!(msg.payload().starts_with(b"BTC"));
+
+            let msg = pass_solana::SignedMessage {
+                context: 1u64,
+                challenge: [0u8; 32],
+                authority_id: [0u8; 32],
+            };
+            assert!(msg.payload().starts_with(b"SOL"));
+
+            let msg = pass_nostr::SignedMessage {
+                context: 1u64,
+                challenge: [0u8; 32],
+                authority_id: [0u8; 32],
+            };
+            assert!(msg.payload().starts_with(b"NOSTR"));
+
+            let msg = pass_ssh::SignedMessage {
+                context: 1u64,
+                challenge: [0u8; 32],
+                authority_id: [0u8; 32],
+            };
+            assert!(msg.payload().starts_with(b"SSH"));
+        })
+    }
+
+    #[test]
+    fn payload_is_unique_for_different_contexts() {
+        // Verify no SCALE length-extension ambiguity:
+        // different (context, challenge) pairs must produce different payloads.
+        new_test_ext().execute_with(|| {
+            let authority = [0u8; 32];
+
+            let msg1 = pass_ethereum::SignedMessage {
+                context: 256u64, // SCALE encodes as [0, 1, 0, 0, 0, 0, 0, 0]
+                challenge: [0u8; 32],
+                authority_id: authority,
+            };
+            let msg2 = pass_ethereum::SignedMessage {
+                context: 1u64, // SCALE encodes as [1, 0, 0, 0, 0, 0, 0, 0]
+                challenge: [0u8; 32],
+                authority_id: authority,
+            };
+
+            assert_ne!(msg1.payload(), msg2.payload());
+
+            // Also verify that context bytes don't bleed into challenge
+            let mut challenge_with_prefix = [0u8; 32];
+            challenge_with_prefix[0] = 1;
+            let msg3 = pass_ethereum::SignedMessage {
+                context: 0u64,
+                challenge: challenge_with_prefix,
+                authority_id: authority,
+            };
+            let msg4 = pass_ethereum::SignedMessage {
+                context: 0u64,
+                challenge: [0u8; 32],
+                authority_id: authority,
+            };
+            assert_ne!(msg3.payload(), msg4.payload());
         })
     }
 }

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -1,0 +1,639 @@
+use crate::mock::*;
+use frame::{
+    deps::sp_core::{ecdsa, ed25519, Pair},
+    testing_prelude::*,
+    traits::TxBaseImplication,
+};
+use sp_io::hashing::keccak_256;
+use traits_authn::{Challenger, ExtrinsicContext, HashedUserId};
+
+// ---------- Helpers ----------
+
+const ETH_USER: HashedUserId = *b"eth_user\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+const SOL_USER: HashedUserId = *b"sol_user\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+const BTC_USER: HashedUserId = *b"btc_user\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+const SSH_USER: HashedUserId = *b"ssh_user\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+parameter_types! {
+    pub EthKey: ecdsa::Pair = ecdsa::Pair::from_seed(&[10u8; 32]);
+    pub SolKey: ed25519::Pair = ed25519::Pair::from_seed(&[11u8; 32]);
+    pub SshKey: ed25519::Pair = ed25519::Pair::from_seed(&[12u8; 32]);
+    pub BtcKey: ecdsa::Pair = ecdsa::Pair::from_seed(&[13u8; 32]);
+    pub EthUserAddress: AccountId = PassPallet::address_for(ETH_USER);
+    pub SolUserAddress: AccountId = PassPallet::address_for(SOL_USER);
+    pub BtcUserAddress: AccountId = PassPallet::address_for(BTC_USER);
+    pub SshUserAddress: AccountId = PassPallet::address_for(SSH_USER);
+}
+
+fn eth_address_of(pair: &ecdsa::Pair) -> pass_ethereum::EthAddress {
+    let dummy = [0u8; 32];
+    let sig = pair.sign_prehashed(&dummy);
+    let pubkey = sp_io::crypto::secp256k1_ecdsa_recover(&sig.0, &dummy)
+        .ok()
+        .unwrap();
+    let hash = keccak_256(&pubkey);
+    let mut addr = [0u8; 20];
+    addr.copy_from_slice(&hash[12..]);
+    pass_ethereum::EthAddress::from_raw(addr)
+}
+
+fn btc_pubkey_hash_of(pair: &ecdsa::Pair) -> pass_bitcoin::BtcPubkeyHash {
+    use ripemd::{Digest, Ripemd160};
+    let dummy = [0u8; 32];
+    let sig = pair.sign_prehashed(&dummy);
+    let pubkey = sp_io::crypto::secp256k1_ecdsa_recover_compressed(&sig.0, &dummy)
+        .ok()
+        .unwrap();
+    let sha = sp_io::hashing::sha2_256(&pubkey);
+    let mut hasher = Ripemd160::new();
+    hasher.update(sha);
+    let h160: [u8; 20] = hasher.finalize().into();
+    pass_bitcoin::BtcPubkeyHash::from_hash160(h160)
+}
+
+fn make_eth_registration(
+    xtc: &impl ExtrinsicContext,
+) -> (pass_ethereum::EthAddress, PassDeviceAttestation) {
+    let context = System::block_number();
+    let message = pass_ethereum::SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: PassAuthority::get(),
+    };
+    let pair = EthKey::get();
+    let address = eth_address_of(&pair);
+    let signature =
+        <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(&message, &pair);
+
+    let attestation = PassDeviceAttestation::Eth(pass_ethereum::EthRegistration {
+        address,
+        message,
+        signature,
+    });
+    (address, attestation)
+}
+
+fn make_sol_registration(
+    xtc: &impl ExtrinsicContext,
+) -> (pass_solana::SolPubkey, PassDeviceAttestation) {
+    let context = System::block_number();
+    let message = pass_solana::SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: PassAuthority::get(),
+    };
+    let pair = SolKey::get();
+    let pubkey = pass_solana::SolPubkey(pair.public().0);
+    let signature =
+        <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(&message, &pair);
+
+    let attestation = PassDeviceAttestation::Sol(pass_solana::SolRegistration {
+        pubkey,
+        message,
+        signature,
+    });
+    (pubkey, attestation)
+}
+
+fn make_btc_registration(
+    xtc: &impl ExtrinsicContext,
+) -> (pass_bitcoin::BtcPubkeyHash, PassDeviceAttestation) {
+    let context = System::block_number();
+    let message = pass_bitcoin::SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: PassAuthority::get(),
+    };
+    let pair = BtcKey::get();
+    let pubkey_hash = btc_pubkey_hash_of(&pair);
+    let signature =
+        <pass_bitcoin::SignedMessage<u64> as pass_bitcoin::Sign<u64>>::sign(&message, &pair);
+
+    let attestation = PassDeviceAttestation::Btc(pass_bitcoin::BtcRegistration {
+        pubkey_hash,
+        message,
+        signature,
+    });
+    (pubkey_hash, attestation)
+}
+
+fn make_ssh_registration(
+    xtc: &impl ExtrinsicContext,
+) -> (pass_ssh::SshPubkey, PassDeviceAttestation) {
+    let context = System::block_number();
+    let message = pass_ssh::SignedMessage {
+        context,
+        challenge: BlockChallenger::generate(&context, xtc),
+        authority_id: PassAuthority::get(),
+    };
+    let pair = SshKey::get();
+    let pubkey = pass_ssh::SshPubkey(pair.public().0);
+    let signature = <pass_ssh::SignedMessage<u64> as pass_ssh::Sign<u64>>::sign(&message, &pair);
+
+    let attestation = PassDeviceAttestation::Ssh(pass_ssh::SshRegistration {
+        pubkey,
+        message,
+        signature,
+    });
+    (pubkey, attestation)
+}
+
+// ---------- Cross-authenticator replay tests ----------
+
+mod cross_authenticator {
+    use super::*;
+
+    fn setup() -> TestExternalities {
+        let mut t = new_test_ext();
+        t.execute_with(|| {
+            // Register ETH device
+            let (_, att) = make_eth_registration(&EthUserAddress::get().encode());
+            assert_ok!(PassPallet::register(RuntimeOrigin::root(), ETH_USER, att));
+
+            // Register SOL device
+            let (_, att) = make_sol_registration(&SolUserAddress::get().encode());
+            assert_ok!(PassPallet::register(RuntimeOrigin::root(), SOL_USER, att));
+
+            // Register BTC device
+            let (_, att) = make_btc_registration(&BtcUserAddress::get().encode());
+            assert_ok!(PassPallet::register(RuntimeOrigin::root(), BTC_USER, att));
+
+            // Register SSH device
+            let (_, att) = make_ssh_registration(&SshUserAddress::get().encode());
+            assert_ok!(PassPallet::register(RuntimeOrigin::root(), SSH_USER, att));
+        });
+        t
+    }
+
+    #[test]
+    fn eth_credential_cannot_authenticate_sol_account() {
+        setup().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+            let xtc =
+                TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
+
+            // Create a valid ETH signature
+            let context = System::block_number();
+            let eth_msg = pass_ethereum::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &xtc),
+                authority_id: PassAuthority::get(),
+            };
+            let eth_sig = <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(
+                &eth_msg,
+                &EthKey::get(),
+            );
+
+            // Wrap in ETH credential but use SOL account's device_id
+            let sol_pubkey = pass_solana::SolPubkey(SolKey::get().public().0);
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                sol_pubkey.0, // SOL's device_id
+                PassCredential::Eth(pass_ethereum::EthSignature {
+                    user_id: SOL_USER, // Try to auth as SOL user
+                    message: eth_msg,
+                    signature: eth_sig,
+                }),
+            );
+
+            assert_noop!(
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
+            );
+        })
+    }
+
+    #[test]
+    fn sol_credential_cannot_authenticate_eth_account() {
+        setup().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+            let xtc =
+                TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
+
+            // Create a valid SOL signature
+            let context = System::block_number();
+            let sol_msg = pass_solana::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &xtc),
+                authority_id: PassAuthority::get(),
+            };
+            let sol_sig = <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(
+                &sol_msg,
+                &SolKey::get(),
+            );
+
+            // Wrap in SOL credential but use ETH account's device_id
+            let eth_addr = eth_address_of(&EthKey::get());
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                *eth_addr.as_ref(), // ETH's device_id
+                PassCredential::Sol(pass_solana::SolSignature {
+                    user_id: ETH_USER, // Try to auth as ETH user
+                    message: sol_msg,
+                    signature: sol_sig,
+                }),
+            );
+
+            assert_noop!(
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
+            );
+        })
+    }
+
+    #[test]
+    fn btc_credential_cannot_authenticate_ssh_account() {
+        setup().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+            let xtc =
+                TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
+
+            let context = System::block_number();
+            let btc_msg = pass_bitcoin::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &xtc),
+                authority_id: PassAuthority::get(),
+            };
+            let btc_sig = <pass_bitcoin::SignedMessage<u64> as pass_bitcoin::Sign<u64>>::sign(
+                &btc_msg,
+                &BtcKey::get(),
+            );
+
+            // Use SSH device_id with BTC credential
+            let ssh_pubkey = pass_ssh::SshPubkey(SshKey::get().public().0);
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                ssh_pubkey.0,
+                PassCredential::Btc(pass_bitcoin::BtcSignature {
+                    user_id: SSH_USER,
+                    message: btc_msg,
+                    signature: btc_sig,
+                }),
+            );
+
+            assert_noop!(
+                ext.validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()),
+                InvalidTransaction::BadSigner
+            );
+        })
+    }
+
+    #[test]
+    fn correct_authenticator_works_in_composite() {
+        setup().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+            let xtc =
+                TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
+
+            // Valid ETH auth
+            let context = System::block_number();
+            let eth_msg = pass_ethereum::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &xtc),
+                authority_id: PassAuthority::get(),
+            };
+            let eth_sig = <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(
+                &eth_msg,
+                &EthKey::get(),
+            );
+            let eth_addr = eth_address_of(&EthKey::get());
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                *eth_addr.as_ref(),
+                PassCredential::Eth(pass_ethereum::EthSignature {
+                    user_id: ETH_USER,
+                    message: eth_msg,
+                    signature: eth_sig,
+                }),
+            );
+
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+        })
+    }
+
+    #[test]
+    fn all_authenticators_work_independently_in_composite() {
+        setup().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+            let xtc =
+                TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
+            let context = System::block_number();
+
+            // SOL auth
+            let sol_msg = pass_solana::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &xtc),
+                authority_id: PassAuthority::get(),
+            };
+            let sol_sig = <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(
+                &sol_msg,
+                &SolKey::get(),
+            );
+            let sol_pubkey = pass_solana::SolPubkey(SolKey::get().public().0);
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                sol_pubkey.0,
+                PassCredential::Sol(pass_solana::SolSignature {
+                    user_id: SOL_USER,
+                    message: sol_msg,
+                    signature: sol_sig,
+                }),
+            );
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+
+            // SSH auth
+            let ssh_msg = pass_ssh::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &xtc),
+                authority_id: PassAuthority::get(),
+            };
+            let ssh_sig = <pass_ssh::SignedMessage<u64> as pass_ssh::Sign<u64>>::sign(
+                &ssh_msg,
+                &SshKey::get(),
+            );
+            let ssh_pubkey = pass_ssh::SshPubkey(SshKey::get().public().0);
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                ssh_pubkey.0,
+                PassCredential::Ssh(pass_ssh::SshSignature {
+                    user_id: SSH_USER,
+                    message: ssh_msg,
+                    signature: ssh_sig,
+                }),
+            );
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+        })
+    }
+}
+
+// ---------- Session key security ----------
+
+mod session_keys {
+    use super::*;
+
+    fn setup_with_eth() -> TestExternalities {
+        let mut t = new_test_ext();
+        t.execute_with(|| {
+            let (_, att) = make_eth_registration(&EthUserAddress::get().encode());
+            assert_ok!(PassPallet::register(RuntimeOrigin::root(), ETH_USER, att));
+        });
+        t
+    }
+
+    #[test]
+    fn session_key_cannot_register_new_account() {
+        setup_with_eth().execute_with(|| {
+            let extrinsic_version: u8 = 0;
+            let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+            let xtc =
+                TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
+
+            // Create a valid session key
+            let context = System::block_number();
+            let eth_msg = pass_ethereum::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &xtc),
+                authority_id: PassAuthority::get(),
+            };
+            let eth_sig = <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(
+                &eth_msg,
+                &EthKey::get(),
+            );
+            let eth_addr = eth_address_of(&EthKey::get());
+
+            let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                *eth_addr.as_ref(),
+                PassCredential::Eth(pass_ethereum::EthSignature {
+                    user_id: ETH_USER,
+                    message: eth_msg,
+                    signature: eth_sig,
+                }),
+            );
+
+            // First verify the auth works
+            assert_ok!(ext
+                .validate_only(
+                    None.into(),
+                    &call,
+                    &call.get_dispatch_info(),
+                    call.encoded_size(),
+                    TransactionSource::External,
+                    0
+                )
+                .map(|_| ()));
+
+            // Now add a session key for this account
+            let session_key_pair = ed25519::Pair::from_seed(&[99u8; 32]);
+            let session_key: AccountId = session_key_pair.public().into();
+
+            // Session keys are ephemeral — they can authenticate but should not
+            // be usable to escalate privileges (e.g., register new accounts).
+            // The session key itself is NOT a registered pass account.
+            // Verify that no pass account maps to this session key's address.
+            let session_addr =
+                PassPallet::address_for(*b"session_test\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0");
+            assert_ne!(session_key, session_addr);
+        })
+    }
+}
+
+// ---------- Device isolation tests ----------
+
+mod device_isolation {
+    use super::*;
+
+    #[test]
+    fn same_ed25519_key_registered_as_sol_and_ssh_are_separate_accounts() {
+        new_test_ext().execute_with(|| {
+            // Use the SAME ed25519 key for both SOL and SSH registrations
+            // Due to domain separators, the signatures will be different
+            // But the DeviceId (raw 32-byte pubkey) is identical
+            let shared_key = ed25519::Pair::from_seed(&[20u8; 32]);
+            let pubkey_bytes = shared_key.public().0;
+
+            let sol_user: HashedUserId = *b"sol_shared\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+            let ssh_user: HashedUserId = *b"ssh_shared\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+            let sol_addr = PassPallet::address_for(sol_user);
+            let ssh_addr = PassPallet::address_for(ssh_user);
+
+            // Register as SOL
+            let context = System::block_number();
+            let sol_msg = pass_solana::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &sol_addr.encode()),
+                authority_id: PassAuthority::get(),
+            };
+            let sol_sig = <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(
+                &sol_msg,
+                &shared_key,
+            );
+            let sol_att = PassDeviceAttestation::Sol(pass_solana::SolRegistration {
+                pubkey: pass_solana::SolPubkey(pubkey_bytes),
+                message: sol_msg,
+                signature: sol_sig,
+            });
+            assert_ok!(PassPallet::register(
+                RuntimeOrigin::root(),
+                sol_user,
+                sol_att
+            ));
+
+            // Try to register the SAME DeviceId as SSH for a different user
+            // pallet-pass should reject because the device_id is already taken
+            let ssh_msg = pass_ssh::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &ssh_addr.encode()),
+                authority_id: PassAuthority::get(),
+            };
+            let ssh_sig =
+                <pass_ssh::SignedMessage<u64> as pass_ssh::Sign<u64>>::sign(&ssh_msg, &shared_key);
+            let ssh_att = PassDeviceAttestation::Ssh(pass_ssh::SshRegistration {
+                pubkey: pass_ssh::SshPubkey(pubkey_bytes),
+                message: ssh_msg,
+                signature: ssh_sig,
+            });
+
+            // This should fail — same device_id cannot be registered to two accounts
+            // (assuming pallet-pass enforces this)
+            let result = PassPallet::register(RuntimeOrigin::root(), ssh_user, ssh_att);
+
+            // If pallet-pass allows it, that's a finding worth documenting
+            if result.is_ok() {
+                // Both registrations succeeded — verify they're on SEPARATE accounts
+                // This means the same physical key controls two accounts
+                // The SOL credential should NOT work for the SSH account
+                let extrinsic_version: u8 = 0;
+                let call: RuntimeCall = frame_system::Call::remark { remark: vec![] }.into();
+                let xtc =
+                    TxBaseImplication((extrinsic_version, call.clone())).using_encoded(blake2_256);
+
+                let sol_auth_msg = pass_solana::SignedMessage {
+                    context,
+                    challenge: BlockChallenger::generate(&context, &xtc),
+                    authority_id: PassAuthority::get(),
+                };
+                let sol_auth_sig =
+                    <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(
+                        &sol_auth_msg,
+                        &shared_key,
+                    );
+
+                // Try SOL credential claiming to be SSH user
+                let ext = pallet_pass::PassAuthenticate::<Test>::from(
+                    pubkey_bytes,
+                    PassCredential::Sol(pass_solana::SolSignature {
+                        user_id: ssh_user, // wrong user
+                        message: sol_auth_msg,
+                        signature: sol_auth_sig,
+                    }),
+                );
+
+                // This MUST fail — composite dispatch (Device::Sol, Cred::Sol) would match
+                // on variant but the device stored is SSH variant for this account
+                assert_noop!(
+                    ext.validate_only(
+                        None.into(),
+                        &call,
+                        &call.get_dispatch_info(),
+                        call.encoded_size(),
+                        TransactionSource::External,
+                        0
+                    )
+                    .map(|_| ()),
+                    InvalidTransaction::BadSigner
+                );
+            }
+        })
+    }
+}
+
+// ---------- Authority mismatch ----------
+
+mod authority {
+    use super::*;
+
+    #[test]
+    fn wrong_authority_id_rejects_registration() {
+        new_test_ext().execute_with(|| {
+            let pair = EthKey::get();
+            let address = eth_address_of(&pair);
+
+            // Use a WRONG authority_id
+            let context = System::block_number();
+            let bad_authority = [0xFFu8; 32];
+            let message = pass_ethereum::SignedMessage {
+                context,
+                challenge: BlockChallenger::generate(&context, &EthUserAddress::get().encode()),
+                authority_id: bad_authority,
+            };
+            let signature = <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(
+                &message, &pair,
+            );
+
+            let attestation = PassDeviceAttestation::Eth(pass_ethereum::EthRegistration {
+                address,
+                message,
+                signature,
+            });
+
+            assert_noop!(
+                PassPallet::register(RuntimeOrigin::root(), ETH_USER, attestation),
+                pallet_pass::Error::<Test>::DeviceAttestationInvalid,
+            );
+        })
+    }
+}

--- a/integration-tests/src/tests.rs
+++ b/integration-tests/src/tests.rs
@@ -62,8 +62,7 @@ fn make_eth_registration(
     };
     let pair = EthKey::get();
     let address = eth_address_of(&pair);
-    let signature =
-        <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(&message, &pair);
+    let signature = message.sign(&pair);
     let attestation = PassDeviceAttestation::Eth(pass_ethereum::EthRegistration {
         address,
         message,
@@ -83,8 +82,7 @@ fn make_sol_registration(
     };
     let pair = SolKey::get();
     let pubkey = pass_solana::SolPubkey(pair.public().0);
-    let signature =
-        <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(&message, &pair);
+    let signature = message.sign(&pair);
     let attestation = PassDeviceAttestation::Sol(pass_solana::SolRegistration {
         pubkey,
         message,
@@ -104,8 +102,7 @@ fn make_btc_registration(
     };
     let pair = BtcKey::get();
     let pubkey_hash = btc_pubkey_hash_of(&pair);
-    let signature =
-        <pass_bitcoin::SignedMessage<u64> as pass_bitcoin::Sign<u64>>::sign(&message, &pair);
+    let signature = message.sign(&pair);
     let attestation = PassDeviceAttestation::Btc(pass_bitcoin::BtcRegistration {
         pubkey_hash,
         message,
@@ -125,7 +122,7 @@ fn make_ssh_registration(
     };
     let pair = SshKey::get();
     let pubkey = pass_ssh::SshPubkey(pair.public().0);
-    let signature = <pass_ssh::SignedMessage<u64> as pass_ssh::Sign<u64>>::sign(&message, &pair);
+    let signature = message.sign(&pair);
     let attestation = PassDeviceAttestation::Ssh(pass_ssh::SshRegistration {
         pubkey,
         message,
@@ -143,8 +140,7 @@ fn make_eth_credential(xtc: &impl ExtrinsicContext) -> (pass_ethereum::EthAddres
     };
     let pair = EthKey::get();
     let address = eth_address_of(&pair);
-    let signature =
-        <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(&message, &pair);
+    let signature = message.sign(&pair);
     let credential = PassCredential::Eth(pass_ethereum::EthSignature {
         user_id: ETH_USER,
         message,
@@ -190,10 +186,7 @@ mod cross_authenticator {
                 challenge: BlockChallenger::generate(&context, &xtc),
                 authority_id: PassAuthority::get(),
             };
-            let eth_sig = <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(
-                &eth_msg,
-                &EthKey::get(),
-            );
+            let eth_sig = eth_msg.sign(&EthKey::get());
 
             // Use SOL device_id with ETH credential → must fail
             let sol_pubkey = pass_solana::SolPubkey(SolKey::get().public().0);
@@ -235,10 +228,7 @@ mod cross_authenticator {
                 challenge: BlockChallenger::generate(&context, &xtc),
                 authority_id: PassAuthority::get(),
             };
-            let sol_sig = <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(
-                &sol_msg,
-                &SolKey::get(),
-            );
+            let sol_sig = sol_msg.sign(&SolKey::get());
 
             let eth_addr = eth_address_of(&EthKey::get());
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
@@ -279,10 +269,7 @@ mod cross_authenticator {
                 challenge: BlockChallenger::generate(&context, &xtc),
                 authority_id: PassAuthority::get(),
             };
-            let btc_sig = <pass_bitcoin::SignedMessage<u64> as pass_bitcoin::Sign<u64>>::sign(
-                &btc_msg,
-                &BtcKey::get(),
-            );
+            let btc_sig = btc_msg.sign(&BtcKey::get());
 
             let ssh_pubkey = pass_ssh::SshPubkey(SshKey::get().public().0);
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
@@ -348,10 +335,7 @@ mod cross_authenticator {
                 challenge: BlockChallenger::generate(&context, &xtc),
                 authority_id: PassAuthority::get(),
             };
-            let sol_sig = <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(
-                &sol_msg,
-                &SolKey::get(),
-            );
+            let sol_sig = sol_msg.sign(&SolKey::get());
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
                 SolKey::get().public().0,
                 PassCredential::Sol(pass_solana::SolSignature {
@@ -377,10 +361,7 @@ mod cross_authenticator {
                 challenge: BlockChallenger::generate(&context, &xtc),
                 authority_id: PassAuthority::get(),
             };
-            let ssh_sig = <pass_ssh::SignedMessage<u64> as pass_ssh::Sign<u64>>::sign(
-                &ssh_msg,
-                &SshKey::get(),
-            );
+            let ssh_sig = ssh_msg.sign(&SshKey::get());
             let ext = pallet_pass::PassAuthenticate::<Test>::from(
                 SshKey::get().public().0,
                 PassCredential::Ssh(pass_ssh::SshSignature {
@@ -429,10 +410,7 @@ mod device_isolation {
                 challenge: BlockChallenger::generate(&context, &sol_addr.encode()),
                 authority_id: PassAuthority::get(),
             };
-            let sol_sig = <pass_solana::SignedMessage<u64> as pass_solana::Sign<u64>>::sign(
-                &sol_msg,
-                &shared_key,
-            );
+            let sol_sig = sol_msg.sign(&shared_key);
             assert_ok!(PassPallet::register(
                 RuntimeOrigin::root(),
                 sol_user,
@@ -450,8 +428,7 @@ mod device_isolation {
                 challenge: BlockChallenger::generate(&context, &ssh_addr.encode()),
                 authority_id: PassAuthority::get(),
             };
-            let ssh_sig =
-                <pass_ssh::SignedMessage<u64> as pass_ssh::Sign<u64>>::sign(&ssh_msg, &shared_key);
+            let ssh_sig = ssh_msg.sign(&shared_key);
 
             assert_noop!(
                 PassPallet::register(
@@ -487,9 +464,7 @@ mod authority {
                 challenge: BlockChallenger::generate(&context, &EthUserAddress::get().encode()),
                 authority_id: bad_authority,
             };
-            let signature = <pass_ethereum::SignedMessage<u64> as pass_ethereum::Sign<u64>>::sign(
-                &message, &pair,
-            );
+            let signature = message.sign(&pair);
 
             assert_noop!(
                 PassPallet::register(


### PR DESCRIPTION
## Summary

- **Ethereum**: secp256k1 + keccak256 `personal_sign` verification (MetaMask, WalletConnect)
- **Bitcoin**: secp256k1 + SHA256d with BIP-137 message signing format
- **Solana**: Ed25519 signature verification (Phantom, Solflare)
- **Nostr**: BIP-340 Schnorr signatures over secp256k1 (NIP-07 compatible)
- **SSH**: Ed25519 with SSHSIG wire format (developer workflows)

Each authenticator follows the same pattern as `substrate-keys`: implements `Authenticator` + `UserAuthenticator` traits from `fc-traits-authn`, with full pallet-pass integration tests (registration + authentication).

## Test plan

- [x] 44 new tests across all 5 authenticators
- [x] Full workspace tests pass (existing substrate-keys + webauthn unaffected)
- [x] Registration and authentication flows tested for each wallet type
- [x] Invalid signature / wrong key / tampered challenge rejection tested

Addresses virto-network/kreivo#479